### PR TITLE
Fixing permissions for canView and canCreate on Discount and OrderCoupon

### DIFF
--- a/code/model/Discount.php
+++ b/code/model/Discount.php
@@ -265,6 +265,14 @@ class Discount extends DataObject{
 		return $orders;
 	}
 
+	public function canView($member = null) {
+		return true;
+	}
+
+	public function canCreate($member = null) {
+		return true;
+	}
+
 	public function canDelete($member = null) {
 		return !$this->isUsed();
 	}

--- a/code/model/OrderCoupon.php
+++ b/code/model/OrderCoupon.php
@@ -104,6 +104,14 @@ class OrderCoupon extends Discount {
 		$this->setField("Code", strtoupper($code));
 	}
 
+	public function canView($member = null) {
+		return true;
+	}
+
+	public function canCreate($member = null) {
+		return true;
+	}
+
 	public function canDelete($member = null) {
 		if($this->getUseCount()) {
 			return false;


### PR DESCRIPTION
If you have access to the "Discounts" CMS section, you can perform all
CRUD actions against Discount and OrderCoupon records.
