### PR TITLE
Versioned issue fixed in product discount constraint

### DIFF
--- a/code/constraints/ProductsDiscountConstraint.php
+++ b/code/constraints/ProductsDiscountConstraint.php
@@ -37,6 +37,7 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint {
             $products = $discount->Products();
 
             if(!$products->exists()) {
+                Versioned::reading_stage($curr);
                 return true;
             }
 


### PR DESCRIPTION
In the stepped checkout this causes a redirect to stage=Stage in the URL because Versioned::reading_stage($curr); is not reset again. The stage remains on Stage instead of Live. Users get the message they have to login to the CMS.