### PR TITLE
Allow extension to work when applied to variations

### DIFF
--- a/src/Extensions/ProductSpecificPricingExtension.php
+++ b/src/Extensions/ProductSpecificPricingExtension.php
@@ -33,7 +33,7 @@ class SpecificPricingExtension extends DataExtension
     public function updateSellingPrice(&$price)
     {
         
-        $list = SpecificPrice::get()->filter( array('ProductID'=>$this->owner->ID, "Price:LessThan"=> $price ));
+        $list = $this->owner->SpecificPrices()->filter( array("Price:LessThan"=> $price ));
         
         if ( $list->exists() && $specificprice = SpecificPrice::filter(
              $list, Member::currentUser() )->first()) {


### PR DESCRIPTION
The original code only worked when extension is applied to a product, but this extension is supposed to also work when applied to a variation.