### PR TITLE
FIX: Fix invalid namespace for CouponFormCheckoutDecorator

### DIFF
--- a/src/Extensions/CouponFormCheckoutDecorator.php
+++ b/src/Extensions/CouponFormCheckoutDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverShop\Discounts\Checkout\Extensions;
+namespace SilverShop\Discounts\Extensions;
 
 use SilverStripe\Core\Extension;
 use SilverShop\Cart\ShoppingCart;


### PR DESCRIPTION
This is (potentially) a breaking change.

The README suggests that you add the extension `SilverShop\Discounts\Extensions\CouponFormCheckoutDecorator` but that extension doesn't exist as there's an additional `Checkout` namespace.

However, if you do add the invalid classname, because of the location of the file, a `class_exists()` check will fail, but Composer's autoloader will correctly load the class, leading to weird failure cases where the file is loaded multiple times and the E_FATAL error `Cannot declare class SilverShop\Discounts\Checkout\Extensions\CouponFormCheckoutDecorator, because the name is already in use`.

Fixing this just requires removing the extra invalid namespace, however that might break people who have loaded the class with the invalid class name and were lucky enough to not attempt to load the class twice (e.g. by calling `Injector::inst()->get(CheckoutPageController::class)` twice).