### PR TITLE
Remove depreciated function (setMultiple) from Discount model

### DIFF
--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -24,7 +24,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
                     'ProductTypes',
                     _t(__CLASS__.'.PRODUCTTYPES', 'Product types'),
                     $this->getTypes(false, $this->owner)
-                )->setMultiple(true)
+                )
             );
         }
     }

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -296,13 +296,11 @@ class Discount extends DataObject implements PermissionProvider
         if (self::config()->filter_by_product) {
             $fields->push(
                 ListboxField::create('Products', 'Products', Product::get()->map()->toArray())
-                    ->setMultiple(true)
             );
         }
         if (self::config()->filter_by_category) {
             $fields->push(
                 ListboxField::create('Categories', 'Categories', ProductCategory::get()->map()->toArray())
-                    ->setMultiple(true)
             );
         }
         if ($field = $fields->fieldByName('Code')) {


### PR DESCRIPTION
setMultiple(https://api.silverstripe.org/3/ListboxField.html) is no longer used as a method for ListboxField in SS4 (https://api.silverstripe.org/4/SilverStripe/Forms/ListboxField.html)