### PR TITLE
feat(Calculator): check for DiscountableAmount using hasMethod

### DIFF
--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -167,7 +167,7 @@ class Calculator
 
         foreach ($this->order->Items() as $item) {
             if (ItemDiscountConstraint::match($item, $discount)) {
-                $amount += method_exists($item, 'DiscountableAmount') ?
+                $amount += $item->hasMethod('DiscountableAmount') ?
                             $item->DiscountableAmount() :
                             $item->Total();
             }


### PR DESCRIPTION
Use hasMethod instead of method_exists when checking DiscountableAmount method. This allows DiscountableAmount method to be used on extensions.