### PR TITLE
Fix incorrect table names

### DIFF
--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -78,14 +78,14 @@ class DiscountModelAdmin extends ModelAdmin
 
         if (isset($params['HasBeenUsed'])) {
             $list = $list
-                ->leftJoin("SilverShop_OrderItem_Discounts", "\"SilverShop_OrderItem_Discounts\".\"DiscountID\" = \"Discount\".\"ID\"")
+                ->leftJoin("SilverShop_Product_OrderItem_Discounts", "\"SilverShop_Product_OrderItem_Discounts\".\"DiscountID\" = \"Discount\".\"ID\"")
                 ->leftJoin("SilverShop_OrderDiscountModifier_Discounts", "\"SilverShop_OrderDiscountModifier_Discounts\".\"DiscountID\" = \"Discount\".\"ID\"")
                 ->innerJoin(
                     "OrderAttribute",
                     implode(
                         " OR ",
                         [
-                        "\"SilverShop_OrderAttribute\".\"ID\" = \"SilverShop_OrderItem_Discounts\".\"Product_OrderItemID\"",
+                        "\"SilverShop_OrderAttribute\".\"ID\" = \"SilverShop_Product_OrderItem_Discounts\".\"Product_OrderItemID\"",
                         "\"SilverShop_OrderAttribute\".\"ID\" = \"SilverShop_OrderDiscountModifier_Discounts\".\"SilverShop_OrderDiscountModifierID\""
                         ]
                     )

--- a/src/Admin/DiscountReport.php
+++ b/src/Admin/DiscountReport.php
@@ -44,8 +44,8 @@ class DiscountReport extends ShopPeriodReport
         $query->addSelect('"SilverShop_Discount".*')
             ->selectField('"Title"', 'Name')
             ->selectField('COUNT(DISTINCT "SilverShop_Order"."ID")', 'Entered')
-            ->addLeftJoin('SilverShop_OrderItem_Discounts',
-                '"SilverShop_OrderItem_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"')
+            ->addLeftJoin('SilverShop_Product_OrderItem_Discounts',
+                '"SilverShop_Product_OrderItem_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"')
             ->addLeftJoin('SilverShop_OrderDiscountModifier_Discounts',
                 '"SilverShop_OrderDiscountModifier_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"')
             ->addInnerJoin(
@@ -53,7 +53,7 @@ class DiscountReport extends ShopPeriodReport
                 (implode(
                     ' OR ',
                     [
-                        '"SilverShop_OrderItem_Discounts"."SilverShop_OrderItemID" = "SilverShop_OrderAttribute"."ID"',
+                        '"SilverShop_Product_OrderItem_Discounts"."SilverShop_Product_OrderItemID" = "SilverShop_OrderAttribute"."ID"',
                         '"SilverShop_OrderDiscountModifier_Discounts"."SilverShop_OrderDiscountModifierID" = "SilverShop_OrderAttribute"."ID"'
                     ]
                 ))

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -515,12 +515,12 @@ class Discount extends DataObject implements PermissionProvider
     {
         $orders =  Order::get()
             ->innerJoin('SilverShop_OrderAttribute', '"SilverShop_OrderAttribute"."OrderID" = "SilverShop_Order"."ID"')
-            ->leftJoin('SilverShop_OrderItem_Discounts',
-                '"SilverShop_OrderItem_Discounts"."SilverShop_OrderItemID" = "SilverShop_OrderAttribute"."ID"')
+            ->leftJoin('SilverShop_Product_OrderItem_Discounts',
+                '"SilverShop_Product_OrderItem_Discounts"."SilverShop_Product_OrderItemID" = "SilverShop_OrderAttribute"."ID"')
             ->leftJoin('SilverShop_OrderDiscountModifier_Discounts',
                 '"SilverShop_OrderDiscountModifier_Discounts"."SilverShop_OrderDiscountModifierID" = "SilverShop_OrderAttribute"."ID"')
             ->where(
-                "SilverShop_OrderItem_Discounts.SilverShop_DiscountID = $this->ID OR SilverShop_OrderDiscountModifier_Discounts.SilverShop_DiscountID = $this->ID
+                "SilverShop_Product_OrderItem_Discounts.SilverShop_DiscountID = $this->ID OR SilverShop_OrderDiscountModifier_Discounts.SilverShop_DiscountID = $this->ID
             "
             );
 
@@ -572,9 +572,9 @@ class Discount extends DataObject implements PermissionProvider
     public function getSavingsForOrder(Order $order)
     {
         $itemsavings = OrderAttribute::get()
-            ->innerJoin('SilverShop_OrderItem_Discounts',
-                '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderItem_Discounts"."SilverShop_OrderItemID"')
-            ->filter('SilverShop_OrderItem_Discounts.DiscountID', $this->ID)
+            ->innerJoin('SilverShop_Product_OrderItem_Discounts',
+                '"SilverShop_OrderAttribute"."ID" = "SilverShop_Product_OrderItem_Discounts"."SilverShop_Product_OrderItemID"')
+            ->filter('SilverShop_Product_OrderItem_Discounts.DiscountID', $this->ID)
             ->filter('OrderAttribute.OrderID', $order->ID)
             ->sum('DiscountAmount');
 


### PR DESCRIPTION
Incorrect table names used in joins breaks the discounts admin interface and the reports interface