### PR TITLE
impr: Permission checks on SpecificPrice model

### DIFF
--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -50,24 +50,31 @@ class SpecificPrice extends DataObject
 
     private static $table_name = 'SilverShop_SpecificPrice';
 
+    public function canView($member = null)
+    {
+        return
+            parent::canView($member) ||
+            Permission::checkMember($member, 'MANAGE_DISCOUNTS');
+    }
+
     public function canEdit($member = null)
     {
         return
-            Permission::check('ADMIN') ||
+            parent::canEdit($member) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
     public function canCreate($member = null, $context = [])
     {
         return
-            Permission::check('ADMIN') ||
+            parent::canCreate($member, $context) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
     public function canDelete($member = null)
     {
         return
-            Permission::check('ADMIN') ||
+            parent::canDelete($member) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 


### PR DESCRIPTION
Explicitly allow members with MANAGE_DISCOUNTS permission to view SpecificPrice objects.

Add fallback to parent canEdit, canCreate, canDelete methods in order to retain ADMIN permission check and extendedCan delegation.