### PR TITLE
fix: Resolve Calculator::getDiscountableAmount incongruity

### DIFF
--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -168,7 +168,7 @@ class Calculator
         foreach ($this->order->Items() as $item) {
             if (ItemDiscountConstraint::match($item, $discount)) {
                 $amount += $item->hasMethod('DiscountableAmount') ?
-                            $item->DiscountableAmount() :
+                            $item->DiscountableAmount() * $item->Quantity :
                             $item->Total();
             }
         }


### PR DESCRIPTION
OrderItem::DiscountableAmount is on a per-unit basis, whereas Calculator::getDiscountableAmount relies on an OrderItem::Total equivalent value.