### PR TITLE
Code upgrade with Rector & PHPStan

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,12 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.yml,package.json}]
-indent_size = 2
+[*.md]
+trim_trailing_whitespace = false
 
-# The indent size used in the package.json file cannot be changed:
-# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+[*.{yml,js,json,css,scss,eslintrc,feature}]
+indent_size = 2
+indent_style = space
+
+[composer.json]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /tests export-ignore
 /docs export-ignore
-/.travis.yml export-ignore
-/phpunit.xml export-ignore
+/phpunit.xml.dist export-ignore
+/phpcs.xml.dist export-ignore
+/.editorconfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    with:
+      composer_require_extra:
+        phpunit/phpunit:^9.6.22
+        symfony/http-foundation:^6.4.8
+        moneyphp/money:^4.6.0
+        silvershop/core:dev-main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
         phpunit/phpunit:^9.6.22
         symfony/http-foundation:^6.4.8
         moneyphp/money:^4.6.0
+        silverstripe/installer:^5.3.0
         silvershop/core:dev-main

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Stable Version](https://poser.pugx.org/silvershop/discounts/v/stable.png)](https://packagist.org/packages/silvershop/discounts)
 [![Latest Unstable Version](https://poser.pugx.org/silvershop/discounts/v/unstable.png)](https://packagist.org/packages/silvershop/discounts)
-[![Build Status](https://secure.travis-ci.org/silvershop/silvershop-discounts.png)](http://travis-ci.org/silvershop/silvershop-discounts)
+[![CI](https://github.com/silvershop/silvershop-discounts/actions/workflows/ci.yml/badge.svg)](https://github.com/silvershop/silvershop-discounts/actions/workflows/ci.yml)
 [![Code Coverage](https://scrutinizer-ci.com/g/silvershop/silvershop-discounts/badges/coverage.png?s=cae0140f6d9a99c35b20c23b8bbe88711d526246)](https://scrutinizer-ci.com/g/silvershop/silvershop-discounts/)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/silvershop/silvershop-discounts/badges/quality-score.png?s=802731e23565b5a7051b5622a56fccb7b764662a)](https://scrutinizer-ci.com/g/silvershop/silvershop-discounts/)
 [![Total Downloads](https://poser.pugx.org/silvershop/discounts/downloads.png)](https://packagist.org/packages/silvershop/discounts)
@@ -33,7 +33,7 @@ Discounts can be globally enabled/disabled.
 	composer require silvershop/discounts dev-master
 ```
 
-If you are using the stepped checkout, add the `CheckoutStep_Discount` checkout 
+If you are using the stepped checkout, add the `CheckoutStep_Discount` checkout
 step:
 
 ```yaml
@@ -43,7 +43,7 @@ SilverShop\Page\CheckoutPage:
 ```
 
 If you would like to display the coupon form seperately to the checkout form,
-apply the following extension. This will make `CouponForm` available in the 
+apply the following extension. This will make `CouponForm` available in the
 checkout template:
 
 ```yaml
@@ -62,8 +62,8 @@ SilverShop\Model\Order:
 
 ## Specific Pricing
 
-Extend `Product` and/or `ProductVariation` with the `SpecificPricingExtension` 
-to introduce a pricing table for each product. This allows admins to set prices 
+Extend `Product` and/or `ProductVariation` with the `SpecificPricingExtension`
+to introduce a pricing table for each product. This allows admins to set prices
 according to things like, date, and membership group.
 
 ```yaml

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -18,10 +18,11 @@ SilverShop\Model\OrderItem:
 SilverShop\Discounts\Model\Discount:
   extensions:
     - SilverShop\Discounts\Extensions\Constraints\CategoriesDiscountConstraint
-    - SilverShop\Discounts\Extensions\Constraints\ProductsDiscountConstraint
+    - SilverShop\Discounts\Extensions\Constraints\CodeDiscountConstraint
+    - SilverShop\Discounts\Extensions\Constraints\DatetimeDiscountConstraint
     - SilverShop\Discounts\Extensions\Constraints\GroupDiscountConstraint
     - SilverShop\Discounts\Extensions\Constraints\MembershipDiscountConstraint
-    - SilverShop\Discounts\Extensions\Constraints\DatetimeDiscountConstraint
-    - SilverShop\Discounts\Extensions\Constraints\ValueDiscountConstraint
+    - SilverShop\Discounts\Extensions\Constraints\ProductsDiscountConstraint
+    - SilverShop\Discounts\Extensions\Constraints\ProductTypeDiscountConstraint
     - SilverShop\Discounts\Extensions\Constraints\UseLimitDiscountConstraint
-    - SilverShop\Discounts\Extensions\Constraints\CodeDiscountConstraint
+    - SilverShop\Discounts\Extensions\Constraints\ValueDiscountConstraint

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,10 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="SilverStripe">
-    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+	<description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
-    <rule ref="PSR2" >
-        <!-- Current exclusions -->
-        <exclude name="PSR1.Methods.CamelCapsMethodName" />
-        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-    </rule>
+	<file>src</file>
+	<file>tests</file>
+
+	<!-- base rules are PSR-2 -->
+	<rule ref="PSR2" >
+		<!-- Current exclusions -->
+		<exclude name="PSR1.Methods.CamelCapsMethodName" />
+		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+		<exclude name="PSR2.Classes.PropertyDeclaration" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
+		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+		<exclude name="Squiz.Scope.MethodScope" />
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+	</rule>
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="spacing" value="1" />
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- use short array syntax (less thirdparty) -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
+		<exclude-pattern>/thirdparty/*</exclude-pattern>
+	</rule>
+
+	<!-- include php files only -->
+	<arg name="extensions" value="php,lib,inc,php5"/>
+
+	<!-- PHP-PEG generated file not intended for human consumption -->
+	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
+	<exclude-pattern>*/_fakewebroot/*</exclude-pattern>
+	<exclude-pattern>*/fixtures/*</exclude-pattern>
 </ruleset>

--- a/src/Actions/DiscountAction.php
+++ b/src/Actions/DiscountAction.php
@@ -49,7 +49,7 @@ abstract class DiscountAction extends Action
 
     public function reduceRemaining(float $amount): static
     {
-        if ($this->remaining) {
+        if ($this->remaining !== 0.0) {
             $this->remaining -= $amount;
         }
 

--- a/src/Actions/DiscountAction.php
+++ b/src/Actions/DiscountAction.php
@@ -6,20 +6,14 @@ use SilverShop\Discounts\Model\Discount;
 
 abstract class DiscountAction extends Action
 {
-    /**
-     * @var Discount
-     */
-    protected $discount;
+    protected Discount $discount;
 
     /**
      * @var float used for keeping total discount within MaxAmount
      */
-    protected $remaining;
+    protected float $remaining;
 
-    /**
-     * @var bool
-     */
-    protected $limited;
+    protected bool $limited;
 
     public function __construct(Discount $discount)
     {
@@ -31,12 +25,8 @@ abstract class DiscountAction extends Action
     /**
      * Limit an amount to be within maximum allowable discount, and update the
      * total remaining discountable amount;
-     *
-     * @param float $amount
-     *
-     * @return float new amount
      */
-    protected function limit($amount)
+    protected function limit(float $amount): float
     {
         if ($this->limited) {
             if ($amount > $this->remaining) {
@@ -51,19 +41,13 @@ abstract class DiscountAction extends Action
 
     /**
      * Check if there is any further allowable amount to be discounted.
-     *
-     * @return boolean
      */
-    protected function hasRemainingDiscount()
+    protected function hasRemainingDiscount(): bool
     {
         return !$this->limited || $this->remaining > 0;
     }
 
-    /**
-     * @param float
-     * @return DiscountAction
-     */
-    public function reduceRemaining($amount)
+    public function reduceRemaining(float $amount): static
     {
         if ($this->remaining) {
             $this->remaining -= $amount;

--- a/src/Actions/ItemDiscountAction.php
+++ b/src/Actions/ItemDiscountAction.php
@@ -25,8 +25,8 @@ abstract class ItemDiscountAction extends DiscountAction
     /**
      * Checks if the given item qualifies for a discount.
      */
-    protected function itemQualifies(ItemPriceInfo $info): bool
+    protected function itemQualifies(ItemPriceInfo $itemPriceInfo): bool
     {
-        return ItemDiscountConstraint::match($info->getItem(), $this->discount);
+        return ItemDiscountConstraint::match($itemPriceInfo->getItem(), $this->discount);
     }
 }

--- a/src/Actions/ItemDiscountAction.php
+++ b/src/Actions/ItemDiscountAction.php
@@ -8,7 +8,7 @@ use SilverShop\Discounts\Extensions\Constraints\ItemDiscountConstraint;
 
 abstract class ItemDiscountAction extends DiscountAction
 {
-    protected $infoitems;
+    protected array $infoitems;
 
     public function __construct(array $infoitems, Discount $discount)
     {
@@ -17,18 +17,15 @@ abstract class ItemDiscountAction extends DiscountAction
         $this->infoitems = $infoitems;
     }
 
-    public function isForItems()
+    public function isForItems(): bool
     {
         return true;
     }
 
     /**
      * Checks if the given item qualifies for a discount.
-     *
-     * @param  ItemPriceInfo $info
-     * @return boolean
      */
-    protected function itemQualifies(ItemPriceInfo $info)
+    protected function itemQualifies(ItemPriceInfo $info): bool
     {
         return ItemDiscountConstraint::match($info->getItem(), $this->discount);
     }

--- a/src/Actions/ItemFixedDiscount.php
+++ b/src/Actions/ItemFixedDiscount.php
@@ -8,16 +8,16 @@ class ItemFixedDiscount extends ItemDiscountAction
 {
     public function perform(): void
     {
-        foreach ($this->infoitems as $info) {
-            if (!$this->itemQualifies($info)) {
+        foreach ($this->infoitems as $infoitem) {
+            if (!$this->itemQualifies($infoitem)) {
                 continue;
             }
 
-            $amount = $this->discount->getDiscountValue($info->getOriginalPrice());
-            $amount *= $info->getQuantity();
+            $amount = $this->discount->getDiscountValue($infoitem->getOriginalPrice());
+            $amount *= $infoitem->getQuantity();
             $amount = $this->limit($amount);
 
-            $info->adjustPrice(new Adjustment($amount, $this->discount));
+            $infoitem->adjustPrice(new Adjustment($amount, $this->discount));
 
             //break the loop if there is no discountable amount left
             if (!$this->hasRemainingDiscount()) {

--- a/src/Actions/ItemFixedDiscount.php
+++ b/src/Actions/ItemFixedDiscount.php
@@ -6,7 +6,7 @@ use SilverShop\Discounts\Adjustment;
 
 class ItemFixedDiscount extends ItemDiscountAction
 {
-    public function perform()
+    public function perform(): void
     {
         foreach ($this->infoitems as $info) {
             if (!$this->itemQualifies($info)) {

--- a/src/Actions/ItemPercentDiscount.php
+++ b/src/Actions/ItemPercentDiscount.php
@@ -12,6 +12,7 @@ class ItemPercentDiscount extends ItemDiscountAction
             if (!$this->itemQualifies($info)) {
                 continue;
             }
+
             $amount = $this->discount->getDiscountValue($info->getOriginalPrice());
             $amount *= $info->getQuantity();
             $amount = $this->limit($amount);

--- a/src/Actions/ItemPercentDiscount.php
+++ b/src/Actions/ItemPercentDiscount.php
@@ -6,7 +6,7 @@ use SilverShop\Discounts\Adjustment;
 
 class ItemPercentDiscount extends ItemDiscountAction
 {
-    public function perform()
+    public function perform(): void
     {
         foreach ($this->infoitems as $info) {
             if (!$this->itemQualifies($info)) {

--- a/src/Actions/ItemPercentDiscount.php
+++ b/src/Actions/ItemPercentDiscount.php
@@ -8,15 +8,15 @@ class ItemPercentDiscount extends ItemDiscountAction
 {
     public function perform(): void
     {
-        foreach ($this->infoitems as $info) {
-            if (!$this->itemQualifies($info)) {
+        foreach ($this->infoitems as $infoitem) {
+            if (!$this->itemQualifies($infoitem)) {
                 continue;
             }
 
-            $amount = $this->discount->getDiscountValue($info->getOriginalPrice());
-            $amount *= $info->getQuantity();
+            $amount = $this->discount->getDiscountValue($infoitem->getOriginalPrice());
+            $amount *= $infoitem->getQuantity();
             $amount = $this->limit($amount);
-            $info->adjustPrice(new Adjustment($amount, $this->discount));
+            $infoitem->adjustPrice(new Adjustment($amount, $this->discount));
             //break the loop if there is no discountable amount left
             if (!$this->hasRemainingDiscount()) {
                 break;

--- a/src/Actions/SubtotalDiscountAction.php
+++ b/src/Actions/SubtotalDiscountAction.php
@@ -23,7 +23,7 @@ class SubtotalDiscountAction extends DiscountAction
         }
     }
 
-    public function perform()
+    public function perform(): float
     {
         $amount =  $this->discount->getDiscountValue($this->subtotal);
 
@@ -36,7 +36,7 @@ class SubtotalDiscountAction extends DiscountAction
         return $amount;
     }
 
-    public function isForItems()
+    public function isForItems(): bool
     {
         return false;
     }

--- a/src/Actions/SubtotalDiscountAction.php
+++ b/src/Actions/SubtotalDiscountAction.php
@@ -31,9 +31,7 @@ class SubtotalDiscountAction extends DiscountAction
             $amount = $this->subtotal;
         }
 
-        $amount = $this->limit($amount);
-
-        return $amount;
+        return $this->limit($amount);
     }
 
     public function isForItems(): bool

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -11,6 +11,7 @@ use Exception;
 class Adjustment
 {
     protected int|float $value;
+
     protected $adjuster;
 
     public function __construct(int|float $val, $adjuster = null)

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -20,7 +20,7 @@ class Adjustment
         $this->adjuster = $adjuster;
     }
 
-    public static function better_of(Adjustment $i, Adjustment $j): static
+    public static function better_of(Adjustment $i, Adjustment $j): Adjustment
     {
         return $i->compareTo($j) > 0 ? $i : $j;
     }

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -43,10 +43,6 @@ class Adjustment
 
     public function __tostring(): string
     {
-        try {
-            return (string) $this->value;
-        } catch (Exception) {
-            return '';
-        }
+        return strval($this->value);
     }
 }

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -6,41 +6,41 @@ use Exception;
 
 /**
  * Stores the calculated adjustment,
- * and the associated object that made the adjustment.
+ * and the associated object that made the adjustment
  */
 class Adjustment
 {
-    protected $value;
-    protected $adjuster;
+    protected int|float $value;
+    protected int|float|null $adjuster;
 
-    public function __construct($val, $adjuster = null)
+    public function __construct(int|float $val, int|float|null $adjuster = null)
     {
         $this->value = $val;
         $this->adjuster = $adjuster;
     }
 
-    public static function better_of(Adjustment $i, Adjustment $j)
+    public static function better_of(Adjustment $i, Adjustment $j): static
     {
         return $i->compareTo($j) > 0 ? $i : $j;
     }
 
     //biggest adjustment = best
-    public function compareTo(Adjustment $i)
+    public function compareTo(Adjustment $i): int|float
     {
         return $this->getValue() - $i->getValue();
     }
 
-    public function getValue()
+    public function getValue(): int|float
     {
         return $this->value;
     }
 
-    public function getAdjuster()
+    public function getAdjuster(): int|float|null
     {
         return $this->adjuster;
     }
 
-    public function __tostring()
+    public function __tostring(): string
     {
         try {
             return (string) $this->value;

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -11,9 +11,9 @@ use Exception;
 class Adjustment
 {
     protected int|float $value;
-    protected int|float|null $adjuster;
+    protected $adjuster;
 
-    public function __construct(int|float $val, int|float|null $adjuster = null)
+    public function __construct(int|float $val, $adjuster = null)
     {
         $this->value = $val;
         $this->adjuster = $adjuster;
@@ -35,7 +35,7 @@ class Adjustment
         return $this->value;
     }
 
-    public function getAdjuster(): int|float|null
+    public function getAdjuster()
     {
         return $this->adjuster;
     }

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -26,9 +26,9 @@ class Adjustment
     }
 
     //biggest adjustment = best
-    public function compareTo(Adjustment $i): int|float
+    public function compareTo(Adjustment $adjustment): int|float
     {
-        return $this->getValue() - $i->getValue();
+        return $this->getValue() - $adjustment->getValue();
     }
 
     public function getValue(): int|float

--- a/src/Adjustment.php
+++ b/src/Adjustment.php
@@ -45,7 +45,7 @@ class Adjustment
     {
         try {
             return (string) $this->value;
-        } catch (Exception $exception) {
+        } catch (Exception) {
             return '';
         }
     }

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -163,7 +163,7 @@ class DiscountModelAdmin extends ModelAdmin
             $count = (int) $data['Number'];
         }
 
-        $prefix = isset($data['Prefix']) ? $data['Prefix'] : '';
+        $prefix = $data['Prefix'] ?? '';
         $length = isset($data['Length']) ? (int) $data['Length'] : OrderCoupon::config()->generated_code_length;
 
         for ($i = 0; $i < $count; $i++) {

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -84,8 +84,8 @@ class DiscountModelAdmin extends ModelAdmin
                     implode(
                         " OR ",
                         [
-                        '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderItem_Discounts"."Product_OrderItemID"',
-                        '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderDiscountModifier_Discounts"."SilverShop_OrderDiscountModifierID"'
+                            '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderItem_Discounts"."Product_OrderItemID"',
+                            '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderDiscountModifier_Discounts"."SilverShop_OrderDiscountModifierID"'
                         ]
                     )
                 );
@@ -133,11 +133,11 @@ class DiscountModelAdmin extends ModelAdmin
         );
 
         $actions = FieldList::create(FormAction::create('generate', 'Generate'));
-        $requiredFields = new RequiredFields(
+        $requiredFields = RequiredFields::create(
             [
-            'Title',
-            'Number',
-            'Type'
+                'Title',
+                'Number',
+                'Type'
             ]
         );
         $form = Form::create($this, 'GenerateCouponsForm', $fieldList, $actions, $requiredFields);
@@ -146,10 +146,10 @@ class DiscountModelAdmin extends ModelAdmin
         $form->setHTMLID('Form_EditForm');
         $form->loadDataFrom(
             [
-            'Number' => 1,
-            'Active' => 1,
-            'ForCart' => 1,
-            'UseLimit' => 1
+                'Number' => 1,
+                'Active' => 1,
+                'ForCart' => 1,
+                'UseLimit' => 1
             ]
         );
         return $form;

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -51,10 +51,10 @@ class DiscountModelAdmin extends ModelAdmin
         if ($grid = $form->Fields()->fieldByName(OrderCoupon::class)) {
             $grid->getConfig()
                 ->addComponent(
-                    $link = new GridField_LinkComponent('Generate Multiple Coupons', $this->Link() . '/generatecoupons'),
+                    $gridFieldLinkComponent = new GridField_LinkComponent('Generate Multiple Coupons', $this->Link() . '/generatecoupons'),
                     'GridFieldExportButton'
                 );
-            $link->addExtraClass('ss-ui-action-constructive');
+            $gridFieldLinkComponent->addExtraClass('ss-ui-action-constructive');
         }
 
         $descriptions = self::config()->get('model_descriptions');
@@ -108,12 +108,12 @@ class DiscountModelAdmin extends ModelAdmin
 
     public function GenerateCouponsForm(): Form
     {
-        $fields = OrderCoupon::create()->getCMSFields();
-        $fields->removeByName('Code');
-        $fields->removeByName('GiftVoucherID');
-        $fields->removeByName('SaveNote');
+        $fieldList = OrderCoupon::create()->getCMSFields();
+        $fieldList->removeByName('Code');
+        $fieldList->removeByName('GiftVoucherID');
+        $fieldList->removeByName('SaveNote');
 
-        $fields->addFieldsToTab(
+        $fieldList->addFieldsToTab(
             'Root.Main',
             [
             NumericField::create('Number', 'Number of Coupons'),
@@ -133,14 +133,14 @@ class DiscountModelAdmin extends ModelAdmin
         );
 
         $actions = FieldList::create(FormAction::create('generate', 'Generate'));
-        $validator = new RequiredFields(
+        $requiredFields = new RequiredFields(
             [
             'Title',
             'Number',
             'Type'
             ]
         );
-        $form = Form::create($this, 'GenerateCouponsForm', $fields, $actions, $validator);
+        $form = Form::create($this, 'GenerateCouponsForm', $fieldList, $actions, $requiredFields);
         $form->addExtraClass('cms-edit-form cms-panel-padded center ui-tabs-panel ui-widget-content ui-corner-bottom');
         $form->setAttribute('data-pjax-fragment', 'CurrentForm');
         $form->setHTMLID('Form_EditForm');

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -98,7 +98,7 @@ class DiscountModelAdmin extends ModelAdmin
         }
 
         if (isset($params['Categories'])) {
-            $list = $list
+            return $list
                 ->innerJoin("Discount_Categories", "Discount_Categories.DiscountID = Discount.ID")
                 ->filter("Discount_Categories.ProductCategoryID", $params['Categories']);
         }

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -51,7 +51,7 @@ class DiscountModelAdmin extends ModelAdmin
         if ($grid = $form->Fields()->fieldByName(OrderCoupon::class)) {
             $grid->getConfig()
                 ->addComponent(
-                    $link = new GridField_LinkComponent('Generate Multiple Coupons', $this->Link(). '/generatecoupons'),
+                    $link = new GridField_LinkComponent('Generate Multiple Coupons', $this->Link() . '/generatecoupons'),
                     'GridFieldExportButton'
                 );
             $link->addExtraClass('ss-ui-action-constructive');

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -132,9 +132,7 @@ class DiscountModelAdmin extends ModelAdmin
             'Title'
         );
 
-        $actions = new FieldList(
-            new FormAction('generate', 'Generate')
-        );
+        $actions = FieldList::create(FormAction::create('generate', 'Generate'));
         $validator = new RequiredFields(
             [
             'Title',
@@ -142,7 +140,7 @@ class DiscountModelAdmin extends ModelAdmin
             'Type'
             ]
         );
-        $form = new Form($this, 'GenerateCouponsForm', $fields, $actions, $validator);
+        $form = Form::create($this, 'GenerateCouponsForm', $fields, $actions, $validator);
         $form->addExtraClass('cms-edit-form cms-panel-padded center ui-tabs-panel ui-widget-content ui-corner-bottom');
         $form->setAttribute('data-pjax-fragment', 'CurrentForm');
         $form->setHTMLID('Form_EditForm');
@@ -169,7 +167,7 @@ class DiscountModelAdmin extends ModelAdmin
         $length = isset($data['Length']) ? (int) $data['Length'] : OrderCoupon::config()->generated_code_length;
 
         for ($i = 0; $i < $count; $i++) {
-            $coupon = new OrderCoupon();
+            $coupon = OrderCoupon::create();
             $form->saveInto($coupon);
 
             $coupon->Code = OrderCoupon::generate_code(

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -3,12 +3,10 @@
 namespace SilverShop\Discounts\Admin;
 
 use SilverStripe\Admin\ModelAdmin;
-
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\DropdownField;
-
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\RequiredFields;
@@ -17,35 +15,36 @@ use SilverShop\Discounts\Model\OrderDiscount;
 use SilverShop\Discounts\Model\OrderCoupon;
 use SilverShop\Discounts\Model\PartialUseDiscount;
 use SilverShop\Discounts\Form\GridField_LinkComponent;
+use SilverStripe\ORM\DataList;
 
 class DiscountModelAdmin extends ModelAdmin
 {
-    private static $url_segment = 'discounts';
+    private static string $url_segment = 'discounts';
 
-    private static $menu_title = 'Discounts';
+    private static string $menu_title = 'Discounts';
 
-    private static $menu_icon = 'silvershop/discounts:images/icon-coupons.png';
+    private static string $menu_icon = 'silvershop/discounts:images/icon-coupons.png';
 
-    private static $menu_priority = 2;
+    private static int $menu_priority = 2;
 
-    private static $managed_models = [
+    private static array $managed_models = [
         OrderDiscount::class,
         OrderCoupon::class,
         PartialUseDiscount::class
     ];
 
-    private static $allowed_actions = [
+    private static array $allowed_actions = [
         'generatecoupons',
         'GenerateCouponsForm'
     ];
 
-    private static $model_descriptions = [
+    private static array $model_descriptions = [
         'OrderDiscount' => 'Discounts are applied at the checkout, based on defined constraints. If not constraints are given, then the discount will always be applied.',
         'OrderCoupon' => 'Coupons are like discounts, but have an associated code.',
         'PartialUseDiscount' => "Partial use discounts are 'amount only' discounts that allow remainder amounts to be used."
     ];
 
-    public function getEditForm($id = null, $fields = null)
+    public function getEditForm($id = null, $fields = null): Form
     {
         $form = parent::getEditForm($id, $fields);
 
@@ -58,7 +57,7 @@ class DiscountModelAdmin extends ModelAdmin
             $link->addExtraClass('ss-ui-action-constructive');
         }
 
-        $descriptions = self::config()->model_descriptions;
+        $descriptions = self::config()->get('model_descriptions');
 
         if (isset($descriptions[$this->modelClass])) {
             $form->Fields()->fieldByName($this->modelClass)
@@ -71,7 +70,7 @@ class DiscountModelAdmin extends ModelAdmin
     /**
      * Update results list, to include custom search filters
      */
-    public function getList()
+    public function getList(): DataList
     {
         $params = $this->request->requestVar('q');
         $list = parent::getList();
@@ -103,11 +102,11 @@ class DiscountModelAdmin extends ModelAdmin
                 ->innerJoin("Discount_Categories", "Discount_Categories.DiscountID = Discount.ID")
                 ->filter("Discount_Categories.ProductCategoryID", $params['Categories']);
         }
-        
+
         return $list;
     }
 
-    public function GenerateCouponsForm()
+    public function GenerateCouponsForm(): Form
     {
         $fields = OrderCoupon::create()->getCMSFields();
         $fields->removeByName('Code');
@@ -158,7 +157,7 @@ class DiscountModelAdmin extends ModelAdmin
         return $form;
     }
 
-    public function generate($data, $form)
+    public function generate($data, $form): void
     {
         $count = 1;
 
@@ -183,7 +182,7 @@ class DiscountModelAdmin extends ModelAdmin
         $this->redirect($this->Link());
     }
 
-    public function generatecoupons()
+    public function generatecoupons(): array
     {
         return [
             'Title' => 'Generate Coupons',

--- a/src/Admin/DiscountModelAdmin.php
+++ b/src/Admin/DiscountModelAdmin.php
@@ -77,15 +77,15 @@ class DiscountModelAdmin extends ModelAdmin
 
         if (isset($params['HasBeenUsed'])) {
             $list = $list
-                ->leftJoin("SilverShop_OrderItem_Discounts", "\"SilverShop_OrderItem_Discounts\".\"DiscountID\" = \"Discount\".\"ID\"")
-                ->leftJoin("SilverShop_OrderDiscountModifier_Discounts", "\"SilverShop_OrderDiscountModifier_Discounts\".\"DiscountID\" = \"Discount\".\"ID\"")
+                ->leftJoin("SilverShop_OrderItem_Discounts", '"SilverShop_OrderItem_Discounts"."DiscountID" = "Discount"."ID"')
+                ->leftJoin("SilverShop_OrderDiscountModifier_Discounts", '"SilverShop_OrderDiscountModifier_Discounts"."DiscountID" = "Discount"."ID"')
                 ->innerJoin(
                     "OrderAttribute",
                     implode(
                         " OR ",
                         [
-                        "\"SilverShop_OrderAttribute\".\"ID\" = \"SilverShop_OrderItem_Discounts\".\"Product_OrderItemID\"",
-                        "\"SilverShop_OrderAttribute\".\"ID\" = \"SilverShop_OrderDiscountModifier_Discounts\".\"SilverShop_OrderDiscountModifierID\""
+                        '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderItem_Discounts"."Product_OrderItemID"',
+                        '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderDiscountModifier_Discounts"."SilverShop_OrderDiscountModifierID"'
                         ]
                     )
                 );
@@ -177,6 +177,7 @@ class DiscountModelAdmin extends ModelAdmin
 
             $coupon->write();
         }
+
         $this->redirect($this->Link());
     }
 

--- a/src/Admin/DiscountReport.php
+++ b/src/Admin/DiscountReport.php
@@ -33,11 +33,11 @@ class DiscountReport extends ShopPeriodReport
     /**
      * Remove unsortable columns
      */
-    public function sortColumns()
+    public function sortColumns(): array
     {
-        $cols = parent::sortColumns();
+        $cols = $this->columns();
         unset($cols['DiscountNice']);
-        return $cols;
+        return array_keys($cols);
     }
 
     public function query($params): ShopReportQuery|SQLSelect

--- a/src/Admin/DiscountReport.php
+++ b/src/Admin/DiscountReport.php
@@ -4,6 +4,8 @@ namespace SilverShop\Discounts\Admin;
 
 use SilverShop\Reports\ShopPeriodReport;
 use SilverShop\Discounts\Model\Discount;
+use SilverShop\Reports\ShopReportQuery;
+use SilverStripe\ORM\Queries\SQLSelect;
 
 class DiscountReport extends ShopPeriodReport
 {
@@ -16,7 +18,7 @@ class DiscountReport extends ShopPeriodReport
     protected $description = "See the total savings for discounts. Note that the 'Entered' field may not be
 										accurate if old/expired carts have been deleted from the database.";
 
-    public function columns()
+    public function columns(): array
     {
         return [
             'Name' => 'Title',
@@ -38,16 +40,20 @@ class DiscountReport extends ShopPeriodReport
         return $cols;
     }
 
-    public function query($params)
+    public function query($params): ShopReportQuery|SQLSelect
     {
         $query = parent::query($params);
         $query->addSelect('"SilverShop_Discount".*')
             ->selectField('"Title"', 'Name')
             ->selectField('COUNT(DISTINCT "SilverShop_Order"."ID")', 'Entered')
-            ->addLeftJoin('SilverShop_OrderItem_Discounts',
-                '"SilverShop_OrderItem_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"')
-            ->addLeftJoin('SilverShop_OrderDiscountModifier_Discounts',
-                '"SilverShop_OrderDiscountModifier_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"')
+            ->addLeftJoin(
+                'SilverShop_OrderItem_Discounts',
+                '"SilverShop_OrderItem_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"'
+            )
+            ->addLeftJoin(
+                'SilverShop_OrderDiscountModifier_Discounts',
+                '"SilverShop_OrderDiscountModifier_Discounts"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"'
+            )
             ->addInnerJoin(
                 'SilverShop_OrderAttribute',
                 (implode(

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -36,8 +36,6 @@ class Calculator
 
     /**
      * Work out the discount for a given order.
-     *
-     * @return double - discount amount
      */
     public function calculate(): int|float
     {
@@ -177,10 +175,8 @@ class Calculator
     /**
      * Work out how much the given discount has already
      * been used
-     *
-     * @return Discount[]
      */
-    protected function discountSubtotal(Discount $discount)
+    protected function discountSubtotal(Discount $discount): string
     {
         return $this->modifier->Discounts()
             ->filter('ID', $discount->ID)

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -110,7 +110,7 @@ class Calculator
         $cartremainder = $cartremainder < 0 ? 0 : $cartremainder;
 
         // select best cart-level discount
-        if ($bestadjustment = $cartpriceinfo->getBestAdjustment()) {
+        if (($bestadjustment = $cartpriceinfo->getBestAdjustment()) instanceof Adjustment) {
             $discount = $bestadjustment->getAdjuster();
             $amount = $bestadjustment->getValue();
             // don't let amount be greater than remainder
@@ -137,7 +137,7 @@ class Calculator
                 );
             }
             //select best shipping-level disount
-            if ($bestadjustment = $shippingpriceinfo->getBestAdjustment()) {
+            if (($bestadjustment = $shippingpriceinfo->getBestAdjustment()) instanceof Adjustment) {
                 $discount = $bestadjustment->getAdjuster();
                 $amount = $bestadjustment->getValue();
                 //don't let amount be greater than remainder

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -164,8 +164,7 @@ class Calculator
         foreach ($this->order->Items() as $hasManyList) {
             if (ItemDiscountConstraint::match($hasManyList, $discount)) {
                 $amount += $hasManyList->hasMethod('DiscountableAmount') ?
-                            $hasManyList->DiscountableAmount() * $hasManyList->Quantity :
-                            $hasManyList->Total();
+                            $hasManyList->DiscountableAmount() * $hasManyList->Quantity : $hasManyList->Total();
             }
         }
 

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -175,9 +175,9 @@ class Calculator
      * Work out how much the given discount has already
      * been used
      */
-    protected function discountSubtotal(Discount $discount): string
+    protected function discountSubtotal(Discount $discount): float
     {
-        return $this->modifier->Discounts()
+        return (float) $this->modifier->Discounts()
             ->filter('ID', $discount->ID)
             ->sum('DiscountAmount');
     }

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -163,11 +163,11 @@ class Calculator
     {
         $amount = 0;
 
-        foreach ($this->order->Items() as $item) {
-            if (ItemDiscountConstraint::match($item, $discount)) {
-                $amount += $item->hasMethod('DiscountableAmount') ?
-                            $item->DiscountableAmount() * $item->Quantity :
-                            $item->Total();
+        foreach ($this->order->Items() as $hasManyList) {
+            if (ItemDiscountConstraint::match($hasManyList, $discount)) {
+                $amount += $hasManyList->hasMethod('DiscountableAmount') ?
+                            $hasManyList->DiscountableAmount() * $hasManyList->Quantity :
+                            $hasManyList->Total();
             }
         }
 
@@ -187,11 +187,11 @@ class Calculator
             ->sum('DiscountAmount');
     }
 
-    protected function createPriceInfoList(DataList $list): array
+    protected function createPriceInfoList(DataList $dataList): array
     {
         $output = [];
 
-        foreach ($list as $item) {
+        foreach ($dataList as $item) {
             $priceInfoClass = $item->getPriceInfoClass();
             if (!$priceInfoClass) {
                 $priceInfoClass = ItemPriceInfo::class;

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -136,6 +136,7 @@ class Calculator
                     new Adjustment($action->perform(), $discount)
                 );
             }
+
             //select best shipping-level disount
             if (($bestadjustment = $shippingpriceinfo->getBestAdjustment()) instanceof Adjustment) {
                 $discount = $bestadjustment->getAdjuster();
@@ -195,8 +196,10 @@ class Calculator
             if (!$priceInfoClass) {
                 $priceInfoClass = ItemPriceInfo::class;
             }
+
             $output[] = Injector::inst()->createWithArgs($priceInfoClass, [$item]);
         }
+
         return $output;
     }
 

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -2,6 +2,7 @@
 
 namespace SilverShop\Discounts;
 
+use SilverStripe\ORM\ArrayList;
 use SilverShop\Discounts\Actions\SubtotalDiscountAction;
 use SilverShop\Discounts\Extensions\Constraints\ItemDiscountConstraint;
 use SilverShop\Discounts\Model\Discount;
@@ -17,13 +18,13 @@ class Calculator
 {
     use Injectable;
 
-    protected $order;
+    protected Order $order;
 
-    protected $discounts;
+    protected ArrayList $discounts;
 
     protected $modifier;
 
-    protected $log = [];
+    protected array $log = [];
 
     public function __construct(Order $order, $context = [])
     {
@@ -38,7 +39,7 @@ class Calculator
      *
      * @return double - discount amount
      */
-    public function calculate()
+    public function calculate(): int|float
     {
         $this->modifier = $this->order->getModifier(
             OrderDiscountModifier::class,
@@ -156,12 +157,8 @@ class Calculator
 
     /**
      * Work out the total discountable amount for a given discount
-     *
-     * @param Discount
-     *
-     * @return float
      */
-    protected function getDiscountableAmount($discount)
+    protected function getDiscountableAmount(Discount $discount): int|float
     {
         $amount = 0;
 
@@ -178,23 +175,18 @@ class Calculator
 
     /**
      * Work out how much the given discount has already
-     * been used.
-     * @param $discount Discount
+     * been used
+     *
      * @return Discount[]
      */
-    protected function discountSubtotal($discount)
+    protected function discountSubtotal(Discount $discount)
     {
         return $this->modifier->Discounts()
             ->filter('ID', $discount->ID)
             ->sum('DiscountAmount');
     }
 
-    /**
-     * @param DataList $list
-     *
-     * @return array
-     */
-    protected function createPriceInfoList(DataList $list)
+    protected function createPriceInfoList(DataList $list): array
     {
         $output = [];
 
@@ -225,12 +217,8 @@ class Calculator
 
     /**
      * Store details about discounts for loggging / debubgging
-     *
-     * @param string   $level
-     * @param double   $amount
-     * @param Discount $discount
      */
-    public function logDiscountAmount($level, $amount, Discount $discount)
+    public function logDiscountAmount(string $level, int|float $amount, Discount $discount): void
     {
         $this->log[] = [
             'Level' => $level,
@@ -239,7 +227,7 @@ class Calculator
         ];
     }
 
-    public function getLog()
+    public function getLog(): array
     {
         return $this->log;
     }

--- a/src/Checkout/CouponCheckoutComponent.php
+++ b/src/Checkout/CouponCheckoutComponent.php
@@ -18,7 +18,7 @@ class CouponCheckoutComponent extends CheckoutComponent
 
     public function getFormFields(Order $order): FieldList
     {
-        $fields = FieldList::create(
+        return FieldList::create(
             TextField::create(
                 'Code',
                 _t(
@@ -27,8 +27,6 @@ class CouponCheckoutComponent extends CheckoutComponent
                 )
             )
         );
-
-        return $fields;
     }
 
     public function setValidWhenBlank(bool $valid): void

--- a/src/Checkout/CouponCheckoutComponent.php
+++ b/src/Checkout/CouponCheckoutComponent.php
@@ -14,9 +14,9 @@ use SilverShop\Model\Order;
 
 class CouponCheckoutComponent extends CheckoutComponent
 {
-    protected $validwhenblank = false;
+    protected bool $validwhenblank = false;
 
-    public function getFormFields(Order $order)
+    public function getFormFields(Order $order): FieldList
     {
         $fields = FieldList::create(
             TextField::create(
@@ -31,18 +31,18 @@ class CouponCheckoutComponent extends CheckoutComponent
         return $fields;
     }
 
-    public function setValidWhenBlank($valid)
+    public function setValidWhenBlank(bool $valid): void
     {
         $this->validwhenblank = $valid;
     }
 
-    public function validateData(Order $order, array $data)
+    public function validateData(Order $order, array $data): bool
     {
         $result = new ValidationResult();
         $code = $data['Code'];
 
         if ($this->validwhenblank && !$code) {
-            return $result;
+            return $result->isValid();
         }
 
         // check the coupon exists, and can be used
@@ -61,23 +61,23 @@ class CouponCheckoutComponent extends CheckoutComponent
             throw new ValidationException($result);
         }
 
-
-        return $result;
+        return $result->isValid();
     }
 
-    public function getData(Order $order)
+    public function getData(Order $order): array
     {
         return [
             'Code' => Controller::curr()->getRequest()->getSession()->get('cart.couponcode')
         ];
     }
 
-    public function setData(Order $order, array $data)
+    public function setData(Order $order, array $data): Order
     {
         if ($data['Code']) {
             Controller::curr()->getRequest()->getSession()->set('cart.couponcode', strtoupper($data['Code']));
         }
 
         $order->getModifier(OrderDiscountModifier::class, true);
+        return $order;
     }
 }

--- a/src/Checkout/CouponCheckoutComponent.php
+++ b/src/Checkout/CouponCheckoutComponent.php
@@ -36,30 +36,30 @@ class CouponCheckoutComponent extends CheckoutComponent
 
     public function validateData(Order $order, array $data): bool
     {
-        $result = new ValidationResult();
+        $validationResult = new ValidationResult();
         $code = $data['Code'];
 
         if ($this->validwhenblank && !$code) {
-            return $result->isValid();
+            return $validationResult->isValid();
         }
 
         // check the coupon exists, and can be used
         if ($coupon = OrderCoupon::get_by_code($code)) {
             if (!$coupon->validateOrder($order, ['CouponCode' => $code])) {
-                $result->addError($coupon->getMessage(), 'Code');
+                $validationResult->addError($coupon->getMessage(), 'Code');
 
-                throw ValidationException::create($result);
+                throw ValidationException::create($validationResult);
             }
         } else {
-            $result->addError(
+            $validationResult->addError(
                 _t('OrderCouponModifier.NOTFOUND', 'Coupon could not be found'),
                 'Code'
             );
 
-            throw ValidationException::create($result);
+            throw ValidationException::create($validationResult);
         }
 
-        return $result->isValid();
+        return $validationResult->isValid();
     }
 
     public function getData(Order $order): array

--- a/src/Checkout/CouponCheckoutComponent.php
+++ b/src/Checkout/CouponCheckoutComponent.php
@@ -72,7 +72,7 @@ class CouponCheckoutComponent extends CheckoutComponent
     public function setData(Order $order, array $data): Order
     {
         if ($data['Code']) {
-            Controller::curr()->getRequest()->getSession()->set('cart.couponcode', strtoupper($data['Code']));
+            Controller::curr()->getRequest()->getSession()->set('cart.couponcode', strtoupper((string) $data['Code']));
         }
 
         $order->getModifier(OrderDiscountModifier::class, true);

--- a/src/Checkout/CouponCheckoutComponent.php
+++ b/src/Checkout/CouponCheckoutComponent.php
@@ -36,7 +36,7 @@ class CouponCheckoutComponent extends CheckoutComponent
 
     public function validateData(Order $order, array $data): bool
     {
-        $validationResult = new ValidationResult();
+        $validationResult = ValidationResult::create();
         $code = $data['Code'];
 
         if ($this->validwhenblank && !$code) {

--- a/src/Checkout/CouponCheckoutComponent.php
+++ b/src/Checkout/CouponCheckoutComponent.php
@@ -50,7 +50,7 @@ class CouponCheckoutComponent extends CheckoutComponent
             if (!$coupon->validateOrder($order, ['CouponCode' => $code])) {
                 $result->addError($coupon->getMessage(), 'Code');
 
-                throw new ValidationException($result);
+                throw ValidationException::create($result);
             }
         } else {
             $result->addError(
@@ -58,7 +58,7 @@ class CouponCheckoutComponent extends CheckoutComponent
                 'Code'
             );
 
-            throw new ValidationException($result);
+            throw ValidationException::create($result);
         }
 
         return $result->isValid();

--- a/src/Checkout/Step/CheckoutStepDiscount.php
+++ b/src/Checkout/Step/CheckoutStepDiscount.php
@@ -22,6 +22,7 @@ class CheckoutStepDiscount extends CheckoutStep
     {
         $config = new CheckoutComponentConfig(ShoppingCart::curr(), true);
         $config->addComponent($comp = new CouponCheckoutComponent());
+
         $comp->setValidWhenBlank(true);
 
         return $config;

--- a/src/Checkout/Step/CheckoutStepDiscount.php
+++ b/src/Checkout/Step/CheckoutStepDiscount.php
@@ -20,8 +20,8 @@ class CheckoutStepDiscount extends CheckoutStep
 
     protected function checkoutconfig(): CheckoutComponentConfig
     {
-        $checkoutComponentConfig = new CheckoutComponentConfig(ShoppingCart::curr(), true);
-        $checkoutComponentConfig->addComponent($couponCheckoutComponent = new CouponCheckoutComponent());
+        $checkoutComponentConfig = CheckoutComponentConfig::create(ShoppingCart::curr(), true);
+        $checkoutComponentConfig->addComponent($couponCheckoutComponent = CouponCheckoutComponent::create());
 
         $couponCheckoutComponent->setValidWhenBlank(true);
 

--- a/src/Checkout/Step/CheckoutStepDiscount.php
+++ b/src/Checkout/Step/CheckoutStepDiscount.php
@@ -13,13 +13,13 @@ use SilverShop\Discounts\Form\CouponForm;
 
 class CheckoutStepDiscount extends CheckoutStep
 {
-    private static $allowed_actions = [
+    private static array $allowed_actions = [
         'discount',
         'CouponForm',
         'setcoupon'
     ];
 
-    protected function checkoutconfig()
+    protected function checkoutconfig(): CheckoutComponentConfig
     {
         $config = new CheckoutComponentConfig(ShoppingCart::curr(), true);
         $config->addComponent($comp = new CouponCheckoutComponent());
@@ -28,14 +28,14 @@ class CheckoutStepDiscount extends CheckoutStep
         return $config;
     }
 
-    public function discount()
+    public function discount(): array
     {
         return [
             'OrderForm' => $this->CouponForm()
         ];
     }
 
-    public function CouponForm()
+    public function CouponForm(): CheckoutForm
     {
         $form = new CheckoutForm($this->owner, 'CouponForm', $this->checkoutconfig());
         $form->setActions(

--- a/src/Checkout/Step/CheckoutStepDiscount.php
+++ b/src/Checkout/Step/CheckoutStepDiscount.php
@@ -20,12 +20,12 @@ class CheckoutStepDiscount extends CheckoutStep
 
     protected function checkoutconfig(): CheckoutComponentConfig
     {
-        $config = new CheckoutComponentConfig(ShoppingCart::curr(), true);
-        $config->addComponent($comp = new CouponCheckoutComponent());
+        $checkoutComponentConfig = new CheckoutComponentConfig(ShoppingCart::curr(), true);
+        $checkoutComponentConfig->addComponent($couponCheckoutComponent = new CouponCheckoutComponent());
 
-        $comp->setValidWhenBlank(true);
+        $couponCheckoutComponent->setValidWhenBlank(true);
 
-        return $config;
+        return $checkoutComponentConfig;
     }
 
     public function discount(): array
@@ -37,13 +37,13 @@ class CheckoutStepDiscount extends CheckoutStep
 
     public function CouponForm(): CheckoutForm
     {
-        $form = CheckoutForm::create($this->owner, 'CouponForm', $this->checkoutconfig());
-        $form->setActions(
+        $checkoutForm = CheckoutForm::create($this->owner, 'CouponForm', $this->checkoutconfig());
+        $checkoutForm->setActions(
             FieldList::create(FormAction::create('setcoupon', _t('SilverShop\Checkout\Step\CheckoutStep.Continue', 'Continue')))
         );
-        $this->owner->extend('updateCouponForm', $form);
+        $this->owner->extend('updateCouponForm', $checkoutForm);
 
-        return $form;
+        return $checkoutForm;
     }
 
     public function setcoupon($data, $form)

--- a/src/Checkout/Step/CheckoutStepDiscount.php
+++ b/src/Checkout/Step/CheckoutStepDiscount.php
@@ -9,7 +9,6 @@ use SilverShop\Discounts\Checkout\CouponCheckoutComponent;
 use SilverShop\Forms\CheckoutForm;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
-use SilverShop\Discounts\Form\CouponForm;
 
 class CheckoutStepDiscount extends CheckoutStep
 {
@@ -37,11 +36,9 @@ class CheckoutStepDiscount extends CheckoutStep
 
     public function CouponForm(): CheckoutForm
     {
-        $form = new CheckoutForm($this->owner, 'CouponForm', $this->checkoutconfig());
+        $form = CheckoutForm::create($this->owner, 'CouponForm', $this->checkoutconfig());
         $form->setActions(
-            new FieldList(
-                FormAction::create('setcoupon', _t('SilverShop\Checkout\Step\CheckoutStep.Continue', 'Continue'))
-            )
+            FieldList::create(FormAction::create('setcoupon', _t('SilverShop\Checkout\Step\CheckoutStep.Continue', 'Continue')))
         );
         $this->owner->extend('updateCouponForm', $form);
 

--- a/src/Extensions/Constraints/CategoriesDiscountConstraint.php
+++ b/src/Extensions/Constraints/CategoriesDiscountConstraint.php
@@ -13,11 +13,11 @@ use SilverShop\Page\ProductCategory;
 
 class CategoriesDiscountConstraint extends ItemDiscountConstraint
 {
-    private static $many_many = [
+    private static array $many_many = [
         'Categories' => ProductCategory::class
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         if ($this->owner->isInDB()) {
             $fields->addFieldToTab(
@@ -34,7 +34,7 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         }
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $categories = $discount->Categories();
 
@@ -51,7 +51,7 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         return $incart;
     }
 
-    public function itemMatchesCriteria(OrderItem $item, Discount $discount)
+    public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
     {
         $discountcategoryids = $discount->Categories()->getIDList();
         if (empty($discountcategoryids)) {

--- a/src/Extensions/Constraints/CategoriesDiscountConstraint.php
+++ b/src/Extensions/Constraints/CategoriesDiscountConstraint.php
@@ -71,6 +71,6 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
             $discountcategoryids
         );
 
-        return !empty($ids);
+        return $ids !== [];
     }
 }

--- a/src/Extensions/Constraints/CategoriesDiscountConstraint.php
+++ b/src/Extensions/Constraints/CategoriesDiscountConstraint.php
@@ -61,11 +61,13 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         if (empty($discountcategoryids)) {
             return true;
         }
+
         //get category ids from buyable
         $buyable = $item->Buyable();
         if (!method_exists($buyable, 'getCategoryIDs')) {
             return false;
         }
+
         $ids = array_intersect(
             $buyable->getCategoryIDs(),
             $discountcategoryids

--- a/src/Extensions/Constraints/CategoriesDiscountConstraint.php
+++ b/src/Extensions/Constraints/CategoriesDiscountConstraint.php
@@ -24,7 +24,7 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
                 'Root.Constraints.ConstraintsTabs.Product',
                 GridField::create(
                     'Categories',
-                    _t(__CLASS__.'.PRODUCTCATEGORIES', 'Product categories'),
+                    _t(__CLASS__ . '.PRODUCTCATEGORIES', 'Product categories'),
                     $this->owner->Categories(),
                     GridFieldConfig_RelationEditor::create()
                         ->removeComponentsByType(GridFieldAddNewButton::class)
@@ -45,7 +45,7 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         $incart = $this->itemsInCart($discount);
 
         if (!$incart) {
-            $this->error(_t(__CLASS__.'.CATEGORIESNOTINCART', 'The required products (categories) are not in the cart.'));
+            $this->error(_t(__CLASS__ . '.CATEGORIESNOTINCART', 'The required products (categories) are not in the cart.'));
         }
 
         return $incart;

--- a/src/Extensions/Constraints/CategoriesDiscountConstraint.php
+++ b/src/Extensions/Constraints/CategoriesDiscountConstraint.php
@@ -2,6 +2,7 @@
 
 namespace SilverShop\Discounts\Extensions\Constraints;
 
+use SilverStripe\ORM\ManyManyList;
 use SilverShop\Discounts\Model\Discount;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
@@ -11,6 +12,9 @@ use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverShop\Model\OrderItem;
 use SilverShop\Page\ProductCategory;
 
+/**
+ * @method ManyManyList<ProductCategory> Categories()
+ */
 class CategoriesDiscountConstraint extends ItemDiscountConstraint
 {
     private static array $many_many = [

--- a/src/Extensions/Constraints/CategoriesDiscountConstraint.php
+++ b/src/Extensions/Constraints/CategoriesDiscountConstraint.php
@@ -21,10 +21,10 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         'Categories' => ProductCategory::class
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
         if ($this->owner->isInDB()) {
-            $fields->addFieldToTab(
+            $fieldList->addFieldToTab(
                 'Root.Constraints.ConstraintsTabs.Product',
                 GridField::create(
                     'Categories',
@@ -40,9 +40,9 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
 
     public function check(Discount $discount): bool
     {
-        $categories = $discount->Categories();
+        $manyManyList = $discount->Categories();
 
-        if (!$categories->exists()) {
+        if (!$manyManyList->exists()) {
             return true;
         }
 
@@ -55,7 +55,7 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         return $incart;
     }
 
-    public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
+    public function itemMatchesCriteria(OrderItem $orderItem, Discount $discount): bool
     {
         $discountcategoryids = $discount->Categories()->getIDList();
         if (empty($discountcategoryids)) {
@@ -63,7 +63,7 @@ class CategoriesDiscountConstraint extends ItemDiscountConstraint
         }
 
         //get category ids from buyable
-        $buyable = $item->Buyable();
+        $buyable = $orderItem->Buyable();
         if (!method_exists($buyable, 'getCategoryIDs')) {
             return false;
         }

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -14,14 +14,14 @@ class CodeDiscountConstraint extends DiscountConstraint
         'Code' => 'Varchar(25)'
     ];
 
-    public function filter(DataList $list): DataList
+    public function filter(DataList $dataList): DataList
     {
         if (($code = $this->findCouponCode()) !== null && ($code = $this->findCouponCode()) !== '' && ($code = $this->findCouponCode()) !== '0') {
-            return $list
+            return $dataList
                 ->where(sprintf("(\"Code\" IS NULL) OR (\"Code\" = '%s')", $code));
         }
 
-        return $list->where('"Code" IS NULL');
+        return $dataList->where('"Code" IS NULL');
     }
 
     public function check(Discount $discount): bool

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -7,11 +7,11 @@ use SilverStripe\ORM\DataList;
 
 class CodeDiscountConstraint extends DiscountConstraint
 {
-    private static $db = [
+    private static array $db = [
         'Code' => 'Varchar(25)'
     ];
 
-    public function filter(DataList $list)
+    public function filter(DataList $list): DataList
     {
         if ($code = $this->findCouponCode()) {
             $list = $list
@@ -23,7 +23,7 @@ class CodeDiscountConstraint extends DiscountConstraint
         return $list;
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $code = strtolower($this->findCouponCode() ?? '');
 
@@ -35,7 +35,7 @@ class CodeDiscountConstraint extends DiscountConstraint
         return true;
     }
 
-    protected function findCouponCode()
+    protected function findCouponCode(): ?string
     {
         return isset($this->context['CouponCode']) ? $this->context['CouponCode'] : null;
     }

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -17,13 +17,11 @@ class CodeDiscountConstraint extends DiscountConstraint
     public function filter(DataList $list): DataList
     {
         if (($code = $this->findCouponCode()) !== null && ($code = $this->findCouponCode()) !== '' && ($code = $this->findCouponCode()) !== '0') {
-            $list = $list
+            return $list
                 ->where(sprintf("(\"Code\" IS NULL) OR (\"Code\" = '%s')", $code));
-        } else {
-            $list = $list->where('"Code" IS NULL');
         }
 
-        return $list;
+        return $list->where('"Code" IS NULL');
     }
 
     public function check(Discount $discount): bool

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -18,7 +18,7 @@ class CodeDiscountConstraint extends DiscountConstraint
     {
         if (($code = $this->findCouponCode()) !== null && ($code = $this->findCouponCode()) !== '' && ($code = $this->findCouponCode()) !== '0') {
             $list = $list
-                ->where("(\"Code\" IS NULL) OR (\"Code\" = '$code')");
+                ->where(sprintf("(\"Code\" IS NULL) OR (\"Code\" = '%s')", $code));
         } else {
             $list = $list->where('"Code" IS NULL');
         }
@@ -31,7 +31,7 @@ class CodeDiscountConstraint extends DiscountConstraint
         $code = strtolower($this->findCouponCode() ?? '');
 
         if ($discount->Code && ($code !== strtolower($discount->Code ?? ''))) {
-            $this->error("Coupon code doesn't match $code");
+            $this->error("Coupon code doesn't match " . $code);
             return false;
         }
 

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -38,6 +38,6 @@ class CodeDiscountConstraint extends DiscountConstraint
 
     protected function findCouponCode(): ?string
     {
-        return isset($this->context['CouponCode']) ? $this->context['CouponCode'] : null;
+        return $this->context['CouponCode'] ?? null;
     }
 }

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -5,6 +5,9 @@ namespace SilverShop\Discounts\Extensions\Constraints;
 use SilverShop\Discounts\Model\Discount;
 use SilverStripe\ORM\DataList;
 
+/**
+ * @property ?string $Code
+ */
 class CodeDiscountConstraint extends DiscountConstraint
 {
     private static array $db = [

--- a/src/Extensions/Constraints/CodeDiscountConstraint.php
+++ b/src/Extensions/Constraints/CodeDiscountConstraint.php
@@ -16,7 +16,7 @@ class CodeDiscountConstraint extends DiscountConstraint
 
     public function filter(DataList $list): DataList
     {
-        if ($code = $this->findCouponCode()) {
+        if (($code = $this->findCouponCode()) !== null && ($code = $this->findCouponCode()) !== '' && ($code = $this->findCouponCode()) !== '0') {
             $list = $list
                 ->where("(\"Code\" IS NULL) OR (\"Code\" = '$code')");
         } else {

--- a/src/Extensions/Constraints/DatetimeDiscountConstraint.php
+++ b/src/Extensions/Constraints/DatetimeDiscountConstraint.php
@@ -10,12 +10,12 @@ use SilverStripe\ORM\DataList;
 
 class DatetimeDiscountConstraint extends DiscountConstraint
 {
-    private static $db = [
+    private static array $db = [
         'StartDate' => 'Datetime',
         'EndDate' => 'Datetime'
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         $fields->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
@@ -30,13 +30,15 @@ class DatetimeDiscountConstraint extends DiscountConstraint
                     _t(__CLASS__.'.RANGEEND', 'End date/time')
                 )
             )->setDescription(
-                _t(__CLASS__.'.ENDTIMEDAYNOTE',
-                    'You should set the end time to 23:59:59, if you want to include the entire end day.')
+                _t(
+                    __CLASS__.'.ENDTIMEDAYNOTE',
+                    'You should set the end time to 23:59:59, if you want to include the entire end day.'
+                )
             )
         );
     }
 
-    public function filter(DataList $list)
+    public function filter(DataList $list): DataList
     {
         // Check whether we are looking at a historic order or a current one
         $datetime = $this->order->Placed ? $this->order->Created : date('Y-m-d H:i:s');
@@ -50,18 +52,16 @@ class DatetimeDiscountConstraint extends DiscountConstraint
             );
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $startDate = null;
         $endDate = null;
 
-        if($discount->StartDate != null)
-        {
+        if($discount->StartDate != null) {
             $startDate = strtotime($discount->StartDate);
         }
-        
-        if($discount->EndDate != null)
-        {
+
+        if($discount->EndDate != null) {
             $endDate = strtotime($discount->EndDate);
         }
 

--- a/src/Extensions/Constraints/DatetimeDiscountConstraint.php
+++ b/src/Extensions/Constraints/DatetimeDiscountConstraint.php
@@ -49,10 +49,10 @@ class DatetimeDiscountConstraint extends DiscountConstraint
 
         //to bad ORM filtering for NULL doesn't work...so we need to use where
         return $list->where(
-            "(\"SilverShop_Discount\".\"StartDate\" IS NULL) OR (\"SilverShop_Discount\".\"StartDate\" < '$datetime')"
+            sprintf("(\"SilverShop_Discount\".\"StartDate\" IS NULL) OR (\"SilverShop_Discount\".\"StartDate\" < '%s')", $datetime)
         )
             ->where(
-                "(\"SilverShop_Discount\".\"EndDate\" IS NULL) OR (\"SilverShop_Discount\".\"EndDate\" > '$datetime')"
+                sprintf("(\"SilverShop_Discount\".\"EndDate\" IS NULL) OR (\"SilverShop_Discount\".\"EndDate\" > '%s')", $datetime)
             );
     }
 

--- a/src/Extensions/Constraints/DatetimeDiscountConstraint.php
+++ b/src/Extensions/Constraints/DatetimeDiscountConstraint.php
@@ -8,6 +8,10 @@ use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\DatetimeField;
 use SilverStripe\ORM\DataList;
 
+/**
+ * @property ?string $StartDate
+ * @property ?string $EndDate
+ */
 class DatetimeDiscountConstraint extends DiscountConstraint
 {
     private static array $db = [

--- a/src/Extensions/Constraints/DatetimeDiscountConstraint.php
+++ b/src/Extensions/Constraints/DatetimeDiscountConstraint.php
@@ -20,18 +20,18 @@ class DatetimeDiscountConstraint extends DiscountConstraint
         $fields->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
             FieldGroup::create(
-                _t(__CLASS__.'.VALIDDATERANGE', 'Valid date range:'),
+                _t(__CLASS__ . '.VALIDDATERANGE', 'Valid date range:'),
                 DatetimeField::create(
                     'StartDate',
-                    _t(__CLASS__.'.RANGESTART', 'Start date/time')
+                    _t(__CLASS__ . '.RANGESTART', 'Start date/time')
                 ),
                 DatetimeField::create(
                     'EndDate',
-                    _t(__CLASS__.'.RANGEEND', 'End date/time')
+                    _t(__CLASS__ . '.RANGEEND', 'End date/time')
                 )
             )->setDescription(
                 _t(
-                    __CLASS__.'.ENDTIMEDAYNOTE',
+                    __CLASS__ . '.ENDTIMEDAYNOTE',
                     'You should set the end time to 23:59:59, if you want to include the entire end day.'
                 )
             )
@@ -57,11 +57,11 @@ class DatetimeDiscountConstraint extends DiscountConstraint
         $startDate = null;
         $endDate = null;
 
-        if($discount->StartDate != null) {
+        if ($discount->StartDate != null) {
             $startDate = strtotime($discount->StartDate);
         }
 
-        if($discount->EndDate != null) {
+        if ($discount->EndDate != null) {
             $endDate = strtotime($discount->EndDate);
         }
 

--- a/src/Extensions/Constraints/DatetimeDiscountConstraint.php
+++ b/src/Extensions/Constraints/DatetimeDiscountConstraint.php
@@ -19,9 +19,9 @@ class DatetimeDiscountConstraint extends DiscountConstraint
         'EndDate' => 'Datetime'
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
-        $fields->addFieldToTab(
+        $fieldList->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
             FieldGroup::create(
                 _t(__CLASS__ . '.VALIDDATERANGE', 'Valid date range:'),
@@ -42,13 +42,13 @@ class DatetimeDiscountConstraint extends DiscountConstraint
         );
     }
 
-    public function filter(DataList $list): DataList
+    public function filter(DataList $dataList): DataList
     {
         // Check whether we are looking at a historic order or a current one
         $datetime = $this->order->Placed ? $this->order->Created : date('Y-m-d H:i:s');
 
         //to bad ORM filtering for NULL doesn't work...so we need to use where
-        return $list->where(
+        return $dataList->where(
             sprintf("(\"SilverShop_Discount\".\"StartDate\" IS NULL) OR (\"SilverShop_Discount\".\"StartDate\" < '%s')", $datetime)
         )
             ->where(

--- a/src/Extensions/Constraints/DiscountConstraint.php
+++ b/src/Extensions/Constraints/DiscountConstraint.php
@@ -2,8 +2,8 @@
 
 namespace SilverShop\Discounts\Extensions\Constraints;
 
+use SilverStripe\Core\Extension;
 use SilverShop\Discounts\Model\Discount;
-use SilverStripe\ORM\DataExtension;
 use SilverShop\Model\Order;
 use SilverStripe\ORM\DataList;
 
@@ -15,8 +15,9 @@ use SilverStripe\ORM\DataList;
  *
  * Constraints are also instantiated on their own. See
  * ItemDiscountConstraint::match and Discount->valid
+ * @extends Extension<static>
  */
-abstract class DiscountConstraint extends DataExtension
+abstract class DiscountConstraint extends Extension
 {
     protected Order $order;
 

--- a/src/Extensions/Constraints/DiscountConstraint.php
+++ b/src/Extensions/Constraints/DiscountConstraint.php
@@ -47,9 +47,9 @@ abstract class DiscountConstraint extends Extension
      *
      * See predefined constraints for examples.
      */
-    public function filter(DataList $discounts): DataList
+    public function filter(DataList $dataList): DataList
     {
-        return $discounts;
+        return $dataList;
     }
 
     /**

--- a/src/Extensions/Constraints/DiscountConstraint.php
+++ b/src/Extensions/Constraints/DiscountConstraint.php
@@ -18,25 +18,23 @@ use SilverStripe\ORM\DataList;
  */
 abstract class DiscountConstraint extends DataExtension
 {
-    protected $order;
+    protected Order $order;
 
-    protected $context;
+    protected array $context = [];
 
-    protected $message;
+    protected string $message = '';
 
-    protected $messagetype;
+    protected string $messagetype = '';
 
-    public function setOrder(Order $order)
+    public function setOrder(Order $order): static
     {
         $this->order = $order;
-
         return $this;
     }
 
-    public function setContext(array $context)
+    public function setContext(array $context): static
     {
         $this->context = $context;
-
         return $this;
     }
 
@@ -47,11 +45,8 @@ abstract class DiscountConstraint extends DataExtension
      * 'X' OR Value IS NULL
      *
      * See predefined constraints for examples.
-     *
-     * @param  DataList $discounts discount list constrain
-     * @return DataList
      */
-    public function filter(DataList $discounts)
+    public function filter(DataList $discounts): DataList
     {
         return $discounts;
     }
@@ -59,29 +54,26 @@ abstract class DiscountConstraint extends DataExtension
     /**
      * Check if the current set order falls within
      * this constraint.
-     *
-     * @param  Discount $discount
-     * @return boolean
      */
-    abstract public function check(Discount $discount);
+    abstract public function check(Discount $discount): bool;
 
-    protected function message($message, $type = 'good')
+    protected function message(string $message, string $type = 'good'): void
     {
         $this->message = $message;
         $this->messagetype = $type;
     }
 
-    protected function error($message)
+    protected function error(string $message): void
     {
         $this->message($message, 'bad');
     }
 
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    public function getMessageType()
+    public function getMessageType(): string
     {
         return $this->messagetype;
     }

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -9,6 +9,10 @@ use SilverStripe\Security\Group;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Security\Member;
 
+/**
+ * @property int $GroupID
+ * @method Group Group()
+ */
 class GroupDiscountConstraint extends DiscountConstraint
 {
     private static array $has_one = [

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -63,6 +63,6 @@ class GroupDiscountConstraint extends DiscountConstraint
 
     public function getMember(): Member
     {
-        return isset($this->context['Member']) ? $this->context['Member'] : $this->order->Member();
+        return $this->context['Member'] ?? $this->order->Member();
     }
 }

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -7,14 +7,15 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Security\Group;
 use SilverStripe\ORM\DataList;
+use SilverStripe\Security\Member;
 
 class GroupDiscountConstraint extends DiscountConstraint
 {
-    private static $has_one = [
+    private static array $has_one = [
         'Group' => Group::class
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         $fields->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.Membership',
@@ -27,7 +28,7 @@ class GroupDiscountConstraint extends DiscountConstraint
         );
     }
 
-    public function filter(DataList $list)
+    public function filter(DataList $list): DataList
     {
         $groupids = [0];
         if ($member = $this->getMember()) {
@@ -39,7 +40,7 @@ class GroupDiscountConstraint extends DiscountConstraint
         return $list->filter('GroupID', $groupids);
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $group = $discount->Group();
         $member = $this->getMember();
@@ -56,7 +57,7 @@ class GroupDiscountConstraint extends DiscountConstraint
         return true;
     }
 
-    public function getMember()
+    public function getMember(): Member
     {
         return isset($this->context['Member']) ? $this->context['Member'] : $this->order->Member();
     }

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -19,9 +19,9 @@ class GroupDiscountConstraint extends DiscountConstraint
         'Group' => Group::class
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
-        $fields->addFieldToTab(
+        $fieldList->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.Membership',
             DropdownField::create(
                 'GroupID',
@@ -32,7 +32,7 @@ class GroupDiscountConstraint extends DiscountConstraint
         );
     }
 
-    public function filter(DataList $list): DataList
+    public function filter(DataList $dataList): DataList
     {
         $groupids = [0];
         if ($member = $this->getMember()) {
@@ -41,7 +41,7 @@ class GroupDiscountConstraint extends DiscountConstraint
                 ->toArray();
         }
 
-        return $list->filter('GroupID', $groupids);
+        return $dataList->filter('GroupID', $groupids);
     }
 
     public function check(Discount $discount): bool

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -21,10 +21,10 @@ class GroupDiscountConstraint extends DiscountConstraint
             'Root.Constraints.ConstraintsTabs.Membership',
             DropdownField::create(
                 'GroupID',
-                _t(__CLASS__.'.MEMBERISINGROUP', 'Member is in group'),
+                _t(__CLASS__ . '.MEMBERISINGROUP', 'Member is in group'),
                 Group::get()->map('ID', 'Title')
             )->setHasEmptyDefault(true)
-            ->setEmptyString(_t(__CLASS__.'.ANYORNOGROUP', 'Any or no group'))
+            ->setEmptyString(_t(__CLASS__ . '.ANYORNOGROUP', 'Any or no group'))
         );
     }
 

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -48,7 +48,7 @@ class GroupDiscountConstraint extends DiscountConstraint
     {
         $group = $discount->Group();
         $member = $this->getMember();
-        if ($group->exists() && (!$member || !$member->inGroup($group))) {
+        if ($group->exists() && (!$member instanceof Member || !$member->inGroup($group))) {
             $this->error(
                 _t(
                     'Discount.GROUPED',

--- a/src/Extensions/Constraints/GroupDiscountConstraint.php
+++ b/src/Extensions/Constraints/GroupDiscountConstraint.php
@@ -11,7 +11,7 @@ use SilverStripe\Security\Member;
 
 /**
  * @property int $GroupID
- * @method Group Group()
+ * @method   Group Group()
  */
 class GroupDiscountConstraint extends DiscountConstraint
 {
@@ -35,7 +35,8 @@ class GroupDiscountConstraint extends DiscountConstraint
     public function filter(DataList $dataList): DataList
     {
         $groupids = [0];
-        if ($member = $this->getMember()) {
+        $member = $this->getMember();
+        if ($member->exists()) {
             $groupids += $member->Groups()
                 ->map('ID', 'ID')
                 ->toArray();

--- a/src/Extensions/Constraints/ItemDiscountConstraint.php
+++ b/src/Extensions/Constraints/ItemDiscountConstraint.php
@@ -19,7 +19,7 @@ abstract class ItemDiscountConstraint extends DiscountConstraint
      * Checks that an item can be discounted for configured constraints.
      * If any constraint check fails, the entire function returns false;
      */
-    public static function match(OrderItem $item, Discount $discount): bool
+    public static function match(OrderItem $orderItem, Discount $discount): bool
     {
         $itemconstraints = ClassInfo::subclassesFor(self::class);
 
@@ -30,8 +30,8 @@ abstract class ItemDiscountConstraint extends DiscountConstraint
         //get only the configured item constraints
         $classes = array_intersect($itemconstraints, $configuredconstraints);
 
-        foreach ($classes as $constraint) {
-            if (!singleton($constraint)->itemMatchesCriteria($item, $discount)) {
+        foreach ($classes as $class) {
+            if (!singleton($class)->itemMatchesCriteria($orderItem, $discount)) {
                 return false;
             }
         }
@@ -43,16 +43,16 @@ abstract class ItemDiscountConstraint extends DiscountConstraint
      * Returns true if the given item sits within this constraint.
      * If there is no constraint set, then it should return true.
      */
-    abstract public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool;
+    abstract public function itemMatchesCriteria(OrderItem $orderItem, Discount $discount): bool;
 
     /**
      * Check if at least one item in cart matches this criteria.
      */
     public function itemsInCart(Discount $discount): bool
     {
-        $items = $this->order->Items();
+        $hasManyList = $this->order->Items();
 
-        foreach ($items as $item) {
+        foreach ($hasManyList as $item) {
             if ($this->itemMatchesCriteria($item, $discount)) {
                 return true;
             }

--- a/src/Extensions/Constraints/ItemDiscountConstraint.php
+++ b/src/Extensions/Constraints/ItemDiscountConstraint.php
@@ -21,7 +21,6 @@ abstract class ItemDiscountConstraint extends DiscountConstraint
      */
     public static function match(OrderItem $item, Discount $discount): bool
     {
-        $singletons = [];
         $itemconstraints = ClassInfo::subclassesFor(self::class);
 
         array_shift($itemconstraints); //exclude abstract base class

--- a/src/Extensions/Constraints/ItemDiscountConstraint.php
+++ b/src/Extensions/Constraints/ItemDiscountConstraint.php
@@ -17,13 +17,9 @@ abstract class ItemDiscountConstraint extends DiscountConstraint
 
     /**
      * Checks that an item can be discounted for configured constraints.
-     *
      * If any constraint check fails, the entire function returns false;
-     * @param OrderItem $item
-     * @param Discount $discount
-     * @return bool
      */
-    public static function match(OrderItem $item, Discount $discount)
+    public static function match(OrderItem $item, Discount $discount): bool
     {
         $singletons = [];
         $itemconstraints = ClassInfo::subclassesFor(self::class);
@@ -46,23 +42,14 @@ abstract class ItemDiscountConstraint extends DiscountConstraint
 
     /**
      * Returns true if the given item sits within this constraint.
-     *
      * If there is no constraint set, then it should return true.
-     *
-     * @param  OrderItem $item
-     * @param  Discount  $discount
-     * @return boolean
      */
-    abstract public function itemMatchesCriteria(OrderItem $item, Discount $discount);
+    abstract public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool;
 
     /**
      * Check if at least one item in cart matches this criteria.
-     *
-     * @param Discount $discount
-     *
-     * @return boolean
      */
-    public function itemsInCart(Discount $discount)
+    public function itemsInCart(Discount $discount): bool
     {
         $items = $this->order->Items();
 

--- a/src/Extensions/Constraints/MembershipDiscountConstraint.php
+++ b/src/Extensions/Constraints/MembershipDiscountConstraint.php
@@ -44,10 +44,11 @@ class MembershipDiscountConstraint extends DiscountConstraint
         if ($member = $this->getMember()) {
             $memberid = $member->ID;
         }
+
         $list = $list->leftJoin(
             'SilverShop_Discount_Members',
             '"SilverShop_Discount_Members"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"'
-        )->where("(\"SilverShop_Discount_Members\".\"MemberID\" IS NULL) OR \"SilverShop_Discount_Members\".\"MemberID\" = $memberid");
+        )->where('("SilverShop_Discount_Members"."MemberID" IS NULL) OR "SilverShop_Discount_Members"."MemberID" = ' . $memberid);
 
         return $list;
     }

--- a/src/Extensions/Constraints/MembershipDiscountConstraint.php
+++ b/src/Extensions/Constraints/MembershipDiscountConstraint.php
@@ -13,11 +13,11 @@ use SilverStripe\Forms\GridField\GridFieldEditButton;
 
 class MembershipDiscountConstraint extends DiscountConstraint
 {
-    private static $many_many = [
+    private static array $many_many = [
         'Members' => Member::class
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         if ($this->owner->isInDB()) {
             $fields->addFieldToTab(
@@ -34,7 +34,7 @@ class MembershipDiscountConstraint extends DiscountConstraint
         }
     }
 
-    public function filter(DataList $list)
+    public function filter(DataList $list): DataList
     {
         $memberid = 0;
         if ($member = $this->getMember()) {
@@ -48,7 +48,7 @@ class MembershipDiscountConstraint extends DiscountConstraint
         return $list;
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $members = $discount->Members();
         $member = $this->getMember();
@@ -65,7 +65,7 @@ class MembershipDiscountConstraint extends DiscountConstraint
         return true;
     }
 
-    public function getMember()
+    public function getMember(): Member
     {
         return isset($this->context['Member']) && is_object($this->context['Member']) ? $this->context['Member'] : $this->order->Member();
     }

--- a/src/Extensions/Constraints/MembershipDiscountConstraint.php
+++ b/src/Extensions/Constraints/MembershipDiscountConstraint.php
@@ -21,10 +21,10 @@ class MembershipDiscountConstraint extends DiscountConstraint
         'Members' => Member::class
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
         if ($this->owner->isInDB()) {
-            $fields->addFieldToTab(
+            $fieldList->addFieldToTab(
                 'Root.Constraints.ConstraintsTabs.Membership',
                 GridField::create(
                     'Members',
@@ -38,26 +38,26 @@ class MembershipDiscountConstraint extends DiscountConstraint
         }
     }
 
-    public function filter(DataList $list): DataList
+    public function filter(DataList $dataList): DataList
     {
         $memberid = 0;
         if ($member = $this->getMember()) {
             $memberid = $member->ID;
         }
 
-        $list = $list->leftJoin(
+        $dataList = $dataList->leftJoin(
             'SilverShop_Discount_Members',
             '"SilverShop_Discount_Members"."SilverShop_DiscountID" = "SilverShop_Discount"."ID"'
         )->where('("SilverShop_Discount_Members"."MemberID" IS NULL) OR "SilverShop_Discount_Members"."MemberID" = ' . $memberid);
 
-        return $list;
+        return $dataList;
     }
 
     public function check(Discount $discount): bool
     {
-        $members = $discount->Members();
+        $manyManyList = $discount->Members();
         $member = $this->getMember();
-        if ($members->exists() && (!$member instanceof Member || !$members->byID($member->ID))) {
+        if ($manyManyList->exists() && (!$member instanceof Member || !$manyManyList->byID($member->ID))) {
             $this->error(
                 _t(
                     'Discount.MEMBERSHIP',

--- a/src/Extensions/Constraints/MembershipDiscountConstraint.php
+++ b/src/Extensions/Constraints/MembershipDiscountConstraint.php
@@ -56,7 +56,7 @@ class MembershipDiscountConstraint extends DiscountConstraint
     {
         $members = $discount->Members();
         $member = $this->getMember();
-        if ($members->exists() && (!$member || !$members->byID($member->ID))) {
+        if ($members->exists() && (!$member instanceof Member || !$members->byID($member->ID))) {
             $this->error(
                 _t(
                     'Discount.MEMBERSHIP',

--- a/src/Extensions/Constraints/MembershipDiscountConstraint.php
+++ b/src/Extensions/Constraints/MembershipDiscountConstraint.php
@@ -2,6 +2,7 @@
 
 namespace SilverShop\Discounts\Extensions\Constraints;
 
+use SilverStripe\ORM\ManyManyList;
 use SilverShop\Discounts\Model\Discount;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
@@ -11,6 +12,9 @@ use SilverStripe\Security\Member;
 use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldEditButton;
 
+/**
+ * @method ManyManyList<Member> Members()
+ */
 class MembershipDiscountConstraint extends DiscountConstraint
 {
     private static array $many_many = [

--- a/src/Extensions/Constraints/MembershipDiscountConstraint.php
+++ b/src/Extensions/Constraints/MembershipDiscountConstraint.php
@@ -41,7 +41,8 @@ class MembershipDiscountConstraint extends DiscountConstraint
     public function filter(DataList $dataList): DataList
     {
         $memberid = 0;
-        if ($member = $this->getMember()) {
+        $member = $this->getMember();
+        if ($member->exists()) {
             $memberid = $member->ID;
         }
 

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -17,11 +17,11 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         'ProductTypes' => 'Text'
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
         //multiselect subtypes of orderitem
         if ($this->owner->isInDB() && $this->owner->ForItems) {
-            $fields->addFieldToTab(
+            $fieldList->addFieldToTab(
                 'Root.Constraints.ConstraintsTabs.Product',
                 ListBoxField::create(
                     'ProductTypes',
@@ -51,14 +51,14 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     /**
      * This function is used by ItemDiscountAction, and the check function above.
      */
-    public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
+    public function itemMatchesCriteria(OrderItem $orderItem, Discount $discount): bool
     {
         $types = $this->getTypes(true, $discount);
         if ($types === null || $types === []) {
             return true;
         }
 
-        $buyable = $item->Buyable();
+        $buyable = $orderItem->Buyable();
         return isset($types[$buyable->class]);
     }
 
@@ -81,8 +81,8 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     {
         $implementors = ClassInfo::implementorsOf('Buyable');
         $classes = [];
-        foreach ($implementors as $class) {
-            $classes = array_merge($classes, array_values(ClassInfo::subclassesFor($class)));
+        foreach ($implementors as $implementor) {
+            $classes = array_merge($classes, array_values(ClassInfo::subclassesFor($implementor)));
         }
 
         $classes = array_combine($classes, $classes);

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -39,6 +39,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         if ($types === null || $types === []) {
             return true;
         }
+
         $incart = $this->itemsInCart($discount);
         if (!$incart) {
             $this->error(_t(__CLASS__ . '.PRODUCTTYPESNOTINCART', 'The required product type(s), are not in the cart.'));
@@ -56,6 +57,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         if ($types === null || $types === []) {
             return true;
         }
+
         $buyable = $item->Buyable();
         return isset($types[$buyable->class]);
     }
@@ -65,11 +67,13 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         $types = $selected ? array_filter(explode(',', $discount->ProductTypes)) : $this->BuyableClasses();
         if ($types && $types !== []) {
             $types = array_combine($types, $types);
-            foreach ($types as $type => $name) {
+            foreach (array_keys($types) as $type) {
                 $types[$type] = singleton($type)->i18n_singular_name();
             }
+
             return $types;
         }
+
         return null;
     }
 
@@ -77,9 +81,10 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     {
         $implementors = ClassInfo::implementorsOf('Buyable');
         $classes = [];
-        foreach ($implementors as $key => $class) {
+        foreach ($implementors as $class) {
             $classes = array_merge($classes, array_values(ClassInfo::subclassesFor($class)));
         }
+
         $classes = array_combine($classes, $classes);
         unset($classes['ProductVariation']);
         return $classes;

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -67,12 +67,12 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         }
 
         $buyable = $orderItem->Buyable();
-        return isset($types[$buyable->class]);
+        return isset($types[$buyable->getClassName()]);
     }
 
     protected function getTypes($selected, Discount $discount): ?array
     {
-        $types = $selected ? array_filter(explode(',', $discount->ProductTypes)) : $this->BuyableClasses();
+        $types = $selected ? array_filter(explode(',', $discount->ProductTypes ?? '')) : $this->BuyableClasses();
         if ($types && $types !== []) {
             $types = array_combine($types, $types);
             foreach (array_keys($types) as $type) {

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -3,10 +3,11 @@
 namespace SilverShop\Discounts\Extensions\Constraints;
 
 use SilverShop\Discounts\Model\Discount;
-use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\ListboxField;
 use SilverShop\Model\OrderItem;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HeaderField;
+use SilverStripe\Forms\ListboxField;
 
 /**
  * @property ?string $ProductTypes
@@ -21,13 +22,20 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     {
         //multiselect subtypes of orderitem
         if ($this->owner->isInDB() && $this->owner->ForItems) {
-            $fieldList->addFieldToTab(
+            $fieldList->addFieldsToTab(
                 'Root.Constraints.ConstraintsTabs.Product',
-                ListBoxField::create(
-                    'ProductTypes',
-                    _t(__CLASS__ . '.PRODUCTTYPES', 'Product types'),
-                    $this->getTypes(false, $this->owner)
-                )
+                [
+                    HeaderField::create(
+                        'ProductTypesHeading',
+                        _t(__CLASS__ . '.PRODUCTTYPES', 'Product types'),
+                        2
+                    )->addExtraClass('grid-field__title'),
+                    ListBoxField::create(
+                        'ProductTypes',
+                        '',
+                        $this->getTypes(false, $this->owner) ?? []
+                    )
+                ]
             );
         }
     }
@@ -86,7 +94,11 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         }
 
         $classes = array_combine($classes, $classes);
-        unset($classes['ProductVariation']);
+
+        if (array_key_exists('ProductVariation', $classes)) {
+            unset($classes['ProductVariation']);
+        }
+
         return $classes;
     }
 }

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -10,11 +10,11 @@ use SilverStripe\Core\ClassInfo;
 
 class ProductTypeDiscountConstraint extends ItemDiscountConstraint
 {
-    private static $db = [
+    private static array $db = [
         'ProductTypes' => 'Text'
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         //multiselect subtypes of orderitem
         if ($this->owner->isInDB() && $this->owner->ForItems) {
@@ -29,7 +29,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         }
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $types = $this->getTypes(true, $discount);
         //valid if no categories defined
@@ -46,11 +46,8 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
 
     /**
      * This function is used by ItemDiscountAction, and the check function above.
-     * @param OrderItem $item
-     * @param Discount $discount
-     * @return bool
      */
-    public function itemMatchesCriteria(OrderItem $item, Discount $discount)
+    public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
     {
         $types = $this->getTypes(true, $discount);
         if (!$types) {
@@ -60,7 +57,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         return isset($types[$buyable->class]);
     }
 
-    protected function getTypes($selected, Discount $discount)
+    protected function getTypes($selected, Discount $discount): ?array
     {
         $types = $selected ? array_filter(explode(',', $discount->ProductTypes)) : $this->BuyableClasses();
         if ($types && !empty($types)) {
@@ -70,9 +67,10 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
             }
             return $types;
         }
+        return null;
     }
 
-    protected function BuyableClasses()
+    protected function BuyableClasses(): array
     {
         $implementors = ClassInfo::implementorsOf('Buyable');
         $classes = [];

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -36,7 +36,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     {
         $types = $this->getTypes(true, $discount);
         //valid if no categories defined
-        if (!$types) {
+        if ($types === null || $types === []) {
             return true;
         }
         $incart = $this->itemsInCart($discount);
@@ -53,7 +53,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
     {
         $types = $this->getTypes(true, $discount);
-        if (!$types) {
+        if ($types === null || $types === []) {
             return true;
         }
         $buyable = $item->Buyable();
@@ -63,7 +63,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
     protected function getTypes($selected, Discount $discount): ?array
     {
         $types = $selected ? array_filter(explode(',', $discount->ProductTypes)) : $this->BuyableClasses();
-        if ($types && !empty($types)) {
+        if ($types && $types !== []) {
             $types = array_combine($types, $types);
             foreach ($types as $type => $name) {
                 $types[$type] = singleton($type)->i18n_singular_name();

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -22,7 +22,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
                 'Root.Constraints.ConstraintsTabs.Product',
                 ListBoxField::create(
                     'ProductTypes',
-                    _t(__CLASS__.'.PRODUCTTYPES', 'Product types'),
+                    _t(__CLASS__ . '.PRODUCTTYPES', 'Product types'),
                     $this->getTypes(false, $this->owner)
                 )
             );
@@ -38,7 +38,7 @@ class ProductTypeDiscountConstraint extends ItemDiscountConstraint
         }
         $incart = $this->itemsInCart($discount);
         if (!$incart) {
-            $this->error(_t(__CLASS__.'.PRODUCTTYPESNOTINCART', 'The required product type(s), are not in the cart.'));
+            $this->error(_t(__CLASS__ . '.PRODUCTTYPESNOTINCART', 'The required product type(s), are not in the cart.'));
         }
 
         return $incart;

--- a/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductTypeDiscountConstraint.php
@@ -8,6 +8,9 @@ use SilverStripe\Forms\ListboxField;
 use SilverShop\Model\OrderItem;
 use SilverStripe\Core\ClassInfo;
 
+/**
+ * @property ?string $ProductTypes
+ */
 class ProductTypeDiscountConstraint extends ItemDiscountConstraint
 {
     private static array $db = [

--- a/src/Extensions/Constraints/ProductsDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductsDiscountConstraint.php
@@ -31,7 +31,7 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
                 [
                     GridField::create(
                         'Products',
-                        _t(__CLASS__.'SPECIFICPRODUCTS', 'Specific products'),
+                        _t(__CLASS__ . 'SPECIFICPRODUCTS', 'Specific products'),
                         $this->owner->Products(),
                         GridFieldConfig_RelationEditor::create()
                             ->removeComponentsByType(GridFieldAddNewButton::class)
@@ -39,7 +39,7 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
                     ),
                     CheckboxField::create(
                         'ExactProducts',
-                        _t(__CLASS__.'.ALLPRODUCTSINCART', 'All the selected products must be present in cart.')
+                        _t(__CLASS__ . '.ALLPRODUCTSINCART', 'All the selected products must be present in cart.')
                     ),
                 ]
             );

--- a/src/Extensions/Constraints/ProductsDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductsDiscountConstraint.php
@@ -2,6 +2,7 @@
 
 namespace SilverShop\Discounts\Extensions\Constraints;
 
+use SilverStripe\ORM\ManyManyList;
 use SilverShop\Discounts\Model\Discount;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
@@ -13,6 +14,10 @@ use SilverStripe\Versioned\Versioned;
 use SilverShop\Model\OrderItem;
 use SilverShop\Page\Product;
 
+/**
+ * @property bool $ExactProducts
+ * @method ManyManyList<Product> Products()
+ */
 class ProductsDiscountConstraint extends ItemDiscountConstraint
 {
     private static array $db = [

--- a/src/Extensions/Constraints/ProductsDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductsDiscountConstraint.php
@@ -28,10 +28,10 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
         'Products' => Product::class
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
         if ($this->owner->isInDB()) {
-            $fields->addFieldsToTab(
+            $fieldList->addFieldsToTab(
                 'Root.Constraints.ConstraintsTabs.Product',
                 [
                     GridField::create(
@@ -61,10 +61,10 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
                 function () use ($discount, &$productIds): void {
                     Versioned::set_stage(Versioned::DRAFT);
 
-                    $products = $discount->Products();
+                    $manyManyList = $discount->Products();
 
-                    if ($products->exists()) {
-                        $productIds = $products->map('ID', 'ID')->toArray();
+                    if ($manyManyList->exists()) {
+                        $productIds = $manyManyList->map('ID', 'ID')->toArray();
                     }
                 }
             );
@@ -98,13 +98,13 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
         return $incart;
     }
 
-    public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
+    public function itemMatchesCriteria(OrderItem $orderItem, Discount $discount): bool
     {
-        $products = $discount->Products();
-        $itemproduct = $item->Product(true); // true forces the current version of product to be retrieved.
+        $manyManyList = $discount->Products();
+        $itemproduct = $orderItem->Product(true); // true forces the current version of product to be retrieved.
 
-        if ($products->exists()) {
-            foreach ($products as $product) {
+        if ($manyManyList->exists()) {
+            foreach ($manyManyList as $product) {
                 // uses 'DiscountedProductID' since some subclasses of buyable could be used as the item product (such as
                 // a bundle) rather than the product stored.
                 if ($product->ID == $itemproduct->DiscountedProductID) {

--- a/src/Extensions/Constraints/ProductsDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductsDiscountConstraint.php
@@ -15,15 +15,15 @@ use SilverShop\Page\Product;
 
 class ProductsDiscountConstraint extends ItemDiscountConstraint
 {
-    private static $db = [
+    private static array $db = [
         'ExactProducts' => 'Boolean'
     ];
 
-    private static $many_many = [
+    private static array $many_many = [
         'Products' => Product::class
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         if ($this->owner->isInDB()) {
             $fields->addFieldsToTab(
@@ -46,14 +46,14 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
         }
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         $products = $discount->Products();
         $productIds = [];
 
         if (!$products->exists()) {
             Versioned::withVersionedMode(
-                function () use ($discount, &$productIds) {
+                function () use ($discount, &$productIds): void {
                     Versioned::set_stage(Versioned::DRAFT);
 
                     $products = $discount->Products();
@@ -93,7 +93,7 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
         return $incart;
     }
 
-    public function itemMatchesCriteria(OrderItem $item, Discount $discount)
+    public function itemMatchesCriteria(OrderItem $item, Discount $discount): bool
     {
         $products = $discount->Products();
         $itemproduct = $item->Product(true); // true forces the current version of product to be retrieved.

--- a/src/Extensions/Constraints/ProductsDiscountConstraint.php
+++ b/src/Extensions/Constraints/ProductsDiscountConstraint.php
@@ -87,7 +87,7 @@ class ProductsDiscountConstraint extends ItemDiscountConstraint
 
         $incart = $discount->ExactProducts ?
             array_values($productIds) === array_values($intersection) :
-            count($intersection) > 0;
+            $intersection !== [];
 
         if (!$incart) {
             $this->error(

--- a/src/Extensions/Constraints/UseLimitDiscountConstraint.php
+++ b/src/Extensions/Constraints/UseLimitDiscountConstraint.php
@@ -22,7 +22,7 @@ class UseLimitDiscountConstraint extends DiscountConstraint
             'Root.Constraints.ConstraintsTabs.General',
             NumericField::create(
                 'UseLimit',
-                _t(__CLASS__.'.USELIMIT', $this->owner->fieldLabel('UseLimit')),
+                _t(__CLASS__ . '.USELIMIT', $this->owner->fieldLabel('UseLimit')),
                 0
             )
             ->setDescription('Note: 0 = unlimited')
@@ -32,8 +32,10 @@ class UseLimitDiscountConstraint extends DiscountConstraint
     public function check(Discount $discount): bool
     {
         if ($discount->UseLimit && $discount->getUseCount($this->order->ID) >= $discount->UseLimit) {
-            $this->error(_t('DiscountConstraint.USELIMITREACHED',
-                'This discount has reached its maximum number of uses.'));
+            $this->error(_t(
+                'DiscountConstraint.USELIMITREACHED',
+                'This discount has reached its maximum number of uses.'
+            ));
 
             return false;
         }

--- a/src/Extensions/Constraints/UseLimitDiscountConstraint.php
+++ b/src/Extensions/Constraints/UseLimitDiscountConstraint.php
@@ -8,15 +8,15 @@ use SilverStripe\Forms\NumericField;
 
 class UseLimitDiscountConstraint extends DiscountConstraint
 {
-    private static $db = [
+    private static array $db = [
         'UseLimit' => 'Int'
     ];
 
-    private static $field_labels = [
+    private static array $field_labels = [
         'UseLimit' => 'Maximum number of uses'
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         $fields->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
@@ -29,7 +29,7 @@ class UseLimitDiscountConstraint extends DiscountConstraint
         );
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         if ($discount->UseLimit && $discount->getUseCount($this->order->ID) >= $discount->UseLimit) {
             $this->error(_t('DiscountConstraint.USELIMITREACHED',

--- a/src/Extensions/Constraints/UseLimitDiscountConstraint.php
+++ b/src/Extensions/Constraints/UseLimitDiscountConstraint.php
@@ -19,9 +19,9 @@ class UseLimitDiscountConstraint extends DiscountConstraint
         'UseLimit' => 'Maximum number of uses'
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
-        $fields->addFieldToTab(
+        $fieldList->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
             NumericField::create(
                 'UseLimit',

--- a/src/Extensions/Constraints/UseLimitDiscountConstraint.php
+++ b/src/Extensions/Constraints/UseLimitDiscountConstraint.php
@@ -6,6 +6,9 @@ use SilverShop\Discounts\Model\Discount;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\NumericField;
 
+/**
+ * @property int $UseLimit
+ */
 class UseLimitDiscountConstraint extends DiscountConstraint
 {
     private static array $db = [

--- a/src/Extensions/Constraints/ValueDiscountConstraint.php
+++ b/src/Extensions/Constraints/ValueDiscountConstraint.php
@@ -7,6 +7,9 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\CurrencyField;
 use SilverStripe\ORM\DataList;
 
+/**
+ * @property float $MinOrderValue
+ */
 class ValueDiscountConstraint extends DiscountConstraint
 {
     private static array $db = [

--- a/src/Extensions/Constraints/ValueDiscountConstraint.php
+++ b/src/Extensions/Constraints/ValueDiscountConstraint.php
@@ -23,7 +23,7 @@ class ValueDiscountConstraint extends DiscountConstraint
             'Root.Constraints.ConstraintsTabs.General',
             CurrencyField::create(
                 'MinOrderValue',
-                _t(__CLASS__.'.MINORDERVALUE', $this->owner->fieldLabel('MinOrderValue'))
+                _t(__CLASS__ . '.MINORDERVALUE', $this->owner->fieldLabel('MinOrderValue'))
             )
         );
     }

--- a/src/Extensions/Constraints/ValueDiscountConstraint.php
+++ b/src/Extensions/Constraints/ValueDiscountConstraint.php
@@ -20,9 +20,9 @@ class ValueDiscountConstraint extends DiscountConstraint
         'MinOrderValue' => 'Minimum subtotal of order'
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
-        $fields->addFieldToTab(
+        $fieldList->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
             CurrencyField::create(
                 'MinOrderValue',
@@ -31,9 +31,9 @@ class ValueDiscountConstraint extends DiscountConstraint
         );
     }
 
-    public function filter(DataList $list): DataList
+    public function filter(DataList $dataList): DataList
     {
-        return $list->filterAny(
+        return $dataList->filterAny(
             [
                 'MinOrderValue' => 0,
                 'MinOrderValue:LessThanOrEqual' => $this->order->SubTotal()

--- a/src/Extensions/Constraints/ValueDiscountConstraint.php
+++ b/src/Extensions/Constraints/ValueDiscountConstraint.php
@@ -9,15 +9,15 @@ use SilverStripe\ORM\DataList;
 
 class ValueDiscountConstraint extends DiscountConstraint
 {
-    private static $db = [
+    private static array $db = [
         'MinOrderValue' => 'Currency'
     ];
 
-    private static $field_labels = [
+    private static array $field_labels = [
         'MinOrderValue' => 'Minimum subtotal of order'
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         $fields->addFieldToTab(
             'Root.Constraints.ConstraintsTabs.General',
@@ -28,17 +28,17 @@ class ValueDiscountConstraint extends DiscountConstraint
         );
     }
 
-    public function filter(DataList $list)
+    public function filter(DataList $list): DataList
     {
         return $list->filterAny(
             [
-            'MinOrderValue' => 0,
-            'MinOrderValue:LessThanOrEqual' => $this->order->SubTotal()
+                'MinOrderValue' => 0,
+                'MinOrderValue:LessThanOrEqual' => $this->order->SubTotal()
             ]
         );
     }
 
-    public function check(Discount $discount)
+    public function check(Discount $discount): bool
     {
         if ($discount->MinOrderValue > 0 && $this->order->SubTotal() < $discount->MinOrderValue) {
             $this->error(

--- a/src/Extensions/CouponFormCheckoutDecorator.php
+++ b/src/Extensions/CouponFormCheckoutDecorator.php
@@ -6,6 +6,9 @@ use SilverStripe\Core\Extension;
 use SilverShop\Cart\ShoppingCart;
 use SilverShop\Discounts\Form\CouponForm;
 
+/**
+ * @extends Extension<static>
+ */
 class CouponFormCheckoutDecorator extends Extension
 {
     private static array $allowed_actions = [
@@ -15,7 +18,7 @@ class CouponFormCheckoutDecorator extends Extension
     public function CouponForm(): ?CouponForm
     {
         if ($cart = ShoppingCart::curr()) {
-            return new CouponForm($this->owner, 'CouponForm', $cart);
+            return CouponForm::create($this->owner, 'CouponForm', $cart);
         }
         return null;
     }

--- a/src/Extensions/CouponFormCheckoutDecorator.php
+++ b/src/Extensions/CouponFormCheckoutDecorator.php
@@ -21,6 +21,7 @@ class CouponFormCheckoutDecorator extends Extension
         if (($cart = ShoppingCart::curr()) instanceof Order) {
             return CouponForm::create($this->owner, 'CouponForm', $cart);
         }
+
         return null;
     }
 }

--- a/src/Extensions/CouponFormCheckoutDecorator.php
+++ b/src/Extensions/CouponFormCheckoutDecorator.php
@@ -8,14 +8,15 @@ use SilverShop\Discounts\Form\CouponForm;
 
 class CouponFormCheckoutDecorator extends Extension
 {
-    private static $allowed_actions = [
+    private static array $allowed_actions = [
         'CouponForm'
     ];
 
-    public function CouponForm()
+    public function CouponForm(): ?CouponForm
     {
         if ($cart = ShoppingCart::curr()) {
             return new CouponForm($this->owner, 'CouponForm', $cart);
         }
+        return null;
     }
 }

--- a/src/Extensions/CouponFormCheckoutDecorator.php
+++ b/src/Extensions/CouponFormCheckoutDecorator.php
@@ -2,6 +2,7 @@
 
 namespace SilverShop\Discounts\Extensions;
 
+use SilverShop\Model\Order;
 use SilverStripe\Core\Extension;
 use SilverShop\Cart\ShoppingCart;
 use SilverShop\Discounts\Form\CouponForm;
@@ -17,7 +18,7 @@ class CouponFormCheckoutDecorator extends Extension
 
     public function CouponForm(): ?CouponForm
     {
-        if ($cart = ShoppingCart::curr()) {
+        if (($cart = ShoppingCart::curr()) instanceof Order) {
             return CouponForm::create($this->owner, 'CouponForm', $cart);
         }
         return null;

--- a/src/Extensions/DiscountedOrderExtension.php
+++ b/src/Extensions/DiscountedOrderExtension.php
@@ -80,6 +80,7 @@ class DiscountedOrderExtension extends Extension
         foreach ($this->owner->Items() as $item) {
             $item->Discounts()->removeAll();
         }
+
         foreach ($this->owner->Modifiers() as $modifier) {
             if ($modifier instanceof OrderDiscountModifier) {
                 $modifier->Discounts()->removeAll();

--- a/src/Extensions/DiscountedOrderExtension.php
+++ b/src/Extensions/DiscountedOrderExtension.php
@@ -22,7 +22,7 @@ class DiscountedOrderExtension extends Extension
     {
         $fieldList->addFieldToTab(
             'Root.Discounts',
-            $grid = GridField::create('Discounts', Config::inst()->get(Discount::class, 'plural_name'), $this->Discounts(), new GridFieldConfig_RecordViewer())
+            $grid = GridField::create('Discounts', Config::inst()->get(Discount::class, 'plural_name'), $this->Discounts(), GridFieldConfig_RecordViewer::create())
         );
 
         $grid->setModelClass(Discount::class);

--- a/src/Extensions/DiscountedOrderExtension.php
+++ b/src/Extensions/DiscountedOrderExtension.php
@@ -2,7 +2,8 @@
 
 namespace SilverShop\Discounts\Extensions;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
+use SilverShop\Model\Order;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
@@ -12,18 +13,16 @@ use SilverShop\Discounts\Model\Discount;
 use SilverShop\Discounts\Model\PartialUseDiscount;
 use SilverShop\Discounts\Model\Modifiers\OrderDiscountModifier;
 
-class DiscountedOrderExtension extends DataExtension
+/**
+ * @extends Extension<Order&static>
+ */
+class DiscountedOrderExtension extends Extension
 {
     public function updateCMSFields(FieldList $fields): void
     {
-        $fields->addFieldsToTab(
+        $fields->addFieldToTab(
             'Root.Discounts',
-            $grid = new GridField(
-                'Discounts',
-                Config::inst()->get(Discount::class, 'plural_name'),
-                $this->Discounts(),
-                new GridFieldConfig_RecordViewer()
-            )
+            $grid = GridField::create('Discounts', Config::inst()->get(Discount::class, 'plural_name'), $this->Discounts(), new GridFieldConfig_RecordViewer())
         );
 
         $grid->setModelClass(Discount::class);
@@ -34,7 +33,7 @@ class DiscountedOrderExtension extends DataExtension
      */
     public function Discounts(): ArrayList
     {
-        $finalDiscounts = new ArrayList();
+        $finalDiscounts = ArrayList::create();
 
         foreach ($this->owner->Modifiers() as $modifier) {
             if ($modifier instanceof OrderDiscountModifier) {

--- a/src/Extensions/DiscountedOrderExtension.php
+++ b/src/Extensions/DiscountedOrderExtension.php
@@ -14,7 +14,7 @@ use SilverShop\Discounts\Model\Modifiers\OrderDiscountModifier;
 
 class DiscountedOrderExtension extends DataExtension
 {
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         $fields->addFieldsToTab(
             'Root.Discounts',
@@ -31,10 +31,8 @@ class DiscountedOrderExtension extends DataExtension
 
     /**
      * Get all discounts that have been applied to an order.
-     *
-     * @return ArrayList
      */
-    public function Discounts()
+    public function Discounts(): ArrayList
     {
         $finalDiscounts = new ArrayList();
 
@@ -60,7 +58,7 @@ class DiscountedOrderExtension extends DataExtension
     /**
      * Remove any partial discounts
      */
-    public function onPlaceOrder()
+    public function onPlaceOrder(): void
     {
         $partials = $this->owner->Discounts()->filter('ClassName', PartialUseDiscount::class);
 
@@ -78,7 +76,7 @@ class DiscountedOrderExtension extends DataExtension
     /**
      * Remove discounts
      */
-    public function removeDiscounts()
+    public function removeDiscounts(): void
     {
         foreach ($this->owner->Items() as $item) {
             $item->Discounts()->removeAll();

--- a/src/Extensions/DiscountedOrderExtension.php
+++ b/src/Extensions/DiscountedOrderExtension.php
@@ -18,9 +18,9 @@ use SilverShop\Discounts\Model\Modifiers\OrderDiscountModifier;
  */
 class DiscountedOrderExtension extends Extension
 {
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
-        $fields->addFieldToTab(
+        $fieldList->addFieldToTab(
             'Root.Discounts',
             $grid = GridField::create('Discounts', Config::inst()->get(Discount::class, 'plural_name'), $this->Discounts(), new GridFieldConfig_RecordViewer())
         );
@@ -33,25 +33,25 @@ class DiscountedOrderExtension extends Extension
      */
     public function Discounts(): ArrayList
     {
-        $finalDiscounts = ArrayList::create();
+        $arrayList = ArrayList::create();
 
-        foreach ($this->owner->Modifiers() as $modifier) {
-            if ($modifier instanceof OrderDiscountModifier) {
-                foreach ($modifier->Discounts() as $discount) {
-                    $finalDiscounts->push($discount);
+        foreach ($this->owner->Modifiers() as $hasManyList) {
+            if ($hasManyList instanceof OrderDiscountModifier) {
+                foreach ($hasManyList->Discounts() as $discount) {
+                    $arrayList->push($discount);
                 }
             }
         }
 
         foreach ($this->owner->Items() as $item) {
             foreach ($item->Discounts() as $discount) {
-                $finalDiscounts->push($discount);
+                $arrayList->push($discount);
             }
         }
 
-        $finalDiscounts->removeDuplicates();
+        $arrayList->removeDuplicates();
 
-        return $finalDiscounts;
+        return $arrayList;
     }
 
     /**
@@ -59,9 +59,9 @@ class DiscountedOrderExtension extends Extension
      */
     public function onPlaceOrder(): void
     {
-        $partials = $this->owner->Discounts()->filter('ClassName', PartialUseDiscount::class);
+        $arrayList = $this->owner->Discounts()->filter('ClassName', PartialUseDiscount::class);
 
-        foreach ($partials as $discount) {
+        foreach ($arrayList as $discount) {
             //only bother creating a remainder discount, if savings have been made
             if ($savings = $discount->getSavingsForOrder($this->owner)) {
                 $discount->createRemainder($savings);
@@ -77,8 +77,8 @@ class DiscountedOrderExtension extends Extension
      */
     public function removeDiscounts(): void
     {
-        foreach ($this->owner->Items() as $item) {
-            $item->Discounts()->removeAll();
+        foreach ($this->owner->Items() as $hasManyList) {
+            $hasManyList->Discounts()->removeAll();
         }
 
         foreach ($this->owner->Modifiers() as $modifier) {

--- a/src/Extensions/DiscountedOrderItem.php
+++ b/src/Extensions/DiscountedOrderItem.php
@@ -9,34 +9,28 @@ use SilverShop\Discounts\ItemPriceInfo;
 
 class DiscountedOrderItem extends DataExtension
 {
-    private static $db = [
+    private static array $db = [
         'Discount' => 'Currency'
     ];
 
-    private static $many_many = [
+    private static array $many_many = [
         'Discounts' => Discount::class
     ];
 
-    private static $many_many_extraFields = [
+    private static array $many_many_extraFields = [
         'Discounts' => [
             'DiscountAmount' => 'Currency'
         ]
     ];
 
-    /**
-     * @return int
-     */
-    public function getDiscountedProductID()
+    public function getDiscountedProductID(): int
     {
         $productKey = OrderItem::config()->buyable_relationship . 'ID';
 
         return $this->owner->{$productKey};
     }
 
-    /**
-     * @return string
-     */
-    public function getPriceInfoClass()
+    public function getPriceInfoClass(): string
     {
         $class = ItemPriceInfo::class;
         $this->owner->extend('updatePriceInfoClass', $class);

--- a/src/Extensions/DiscountedOrderItem.php
+++ b/src/Extensions/DiscountedOrderItem.php
@@ -2,12 +2,18 @@
 
 namespace SilverShop\Discounts\Extensions;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\ManyManyList;
 use SilverShop\Model\OrderItem;
 use SilverShop\Discounts\Model\Discount;
 use SilverShop\Discounts\ItemPriceInfo;
 
-class DiscountedOrderItem extends DataExtension
+/**
+ * @property float $Discount
+ * @method ManyManyList<Discount> Discounts()
+ * @extends Extension<OrderItem&static>
+ */
+class DiscountedOrderItem extends Extension
 {
     private static array $db = [
         'Discount' => 'Currency'

--- a/src/Extensions/ProductDiscountExtension.php
+++ b/src/Extensions/ProductDiscountExtension.php
@@ -6,18 +6,14 @@ use SilverStripe\ORM\DataExtension;
 
 class ProductDiscountExtension extends DataExtension
 {
-    private static $casting = [
+    private static array $casting = [
         'TotalReduction' => 'Currency'
     ];
 
     /**
      * Get the difference between the original price and the new price.
-     *
-     * @param string $original
-     *
-     * @return float
      */
-    public function getTotalReduction($original = 'BasePrice')
+    public function getTotalReduction($original = 'BasePrice'): int|float
     {
         $reduction = $this->owner->{$original} - $this->owner->sellingPrice();
         //keep it above 0;
@@ -27,18 +23,13 @@ class ProductDiscountExtension extends DataExtension
 
     /**
      * Check if this product or variation has a reduced price.
-     *
-     * @return bool
      */
-    public function IsReduced()
+    public function IsReduced(): bool
     {
         return (bool) $this->getTotalReduction();
     }
 
-    /**
-     * @return int
-     */
-    public function getDiscountedProductID()
+    public function getDiscountedProductID(): int
     {
         return $this->owner->ID;
     }

--- a/src/Extensions/ProductDiscountExtension.php
+++ b/src/Extensions/ProductDiscountExtension.php
@@ -4,6 +4,7 @@ namespace SilverShop\Discounts\Extensions;
 
 use SilverStripe\Core\Extension;
 use SilverShop\Page\Product;
+
 /**
  * @extends Extension<Product&static>
  */

--- a/src/Extensions/ProductDiscountExtension.php
+++ b/src/Extensions/ProductDiscountExtension.php
@@ -2,9 +2,12 @@
 
 namespace SilverShop\Discounts\Extensions;
 
-use SilverStripe\ORM\DataExtension;
-
-class ProductDiscountExtension extends DataExtension
+use SilverStripe\Core\Extension;
+use SilverShop\Page\Product;
+/**
+ * @extends Extension<Product&static>
+ */
+class ProductDiscountExtension extends Extension
 {
     private static array $casting = [
         'TotalReduction' => 'Currency'

--- a/src/Extensions/ProductVariationDiscountExtension.php
+++ b/src/Extensions/ProductVariationDiscountExtension.php
@@ -6,18 +6,14 @@ use SilverStripe\ORM\DataExtension;
 
 class ProductVariationDiscountExtension extends DataExtension
 {
-    private static $casting = [
+    private static array $casting = [
         'TotalReduction' => 'Currency'
     ];
 
     /**
      * Get the difference between the original price and the new price.
-     *
-     * @param string $original
-     *
-     * @return float
      */
-    public function getTotalReduction($original = 'Price')
+    public function getTotalReduction($original = 'Price'): int|float
     {
         $reduction = $this->owner->{$original} - $this->owner->sellingPrice();
         //keep it above 0;
@@ -27,10 +23,8 @@ class ProductVariationDiscountExtension extends DataExtension
 
     /**
      * Check if this variation has a reduced price.
-     *
-     * @return bool
      */
-    public function IsReduced()
+    public function IsReduced(): bool
     {
         return (bool)$this->getTotalReduction();
     }

--- a/src/Extensions/ProductVariationDiscountExtension.php
+++ b/src/Extensions/ProductVariationDiscountExtension.php
@@ -4,6 +4,7 @@ namespace SilverShop\Discounts\Extensions;
 
 use SilverStripe\Core\Extension;
 use SilverShop\Model\Variation\Variation;
+
 /**
  * @extends Extension<Variation&static>
  */

--- a/src/Extensions/ProductVariationDiscountExtension.php
+++ b/src/Extensions/ProductVariationDiscountExtension.php
@@ -2,9 +2,12 @@
 
 namespace SilverShop\Discounts\Extensions;
 
-use SilverStripe\ORM\DataExtension;
-
-class ProductVariationDiscountExtension extends DataExtension
+use SilverStripe\Core\Extension;
+use SilverShop\Model\Variation\Variation;
+/**
+ * @extends Extension<Variation&static>
+ */
+class ProductVariationDiscountExtension extends Extension
 {
     private static array $casting = [
         'TotalReduction' => 'Currency'

--- a/src/Extensions/SpecificPricingExtension.php
+++ b/src/Extensions/SpecificPricingExtension.php
@@ -2,14 +2,19 @@
 
 namespace SilverShop\Discounts\Extensions;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\HasManyList;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverShop\Discounts\Model\SpecificPrice;
 use SilverStripe\Security\Security;
 
-class SpecificPricingExtension extends DataExtension
+/**
+ * @method HasManyList<SpecificPrice> SpecificPrices()
+ * @extends Extension<static>
+ */
+class SpecificPricingExtension extends Extension
 {
     private static array $has_many = [
         'SpecificPrices' => SpecificPrice::class

--- a/src/Extensions/SpecificPricingExtension.php
+++ b/src/Extensions/SpecificPricingExtension.php
@@ -11,11 +11,11 @@ use SilverStripe\Security\Security;
 
 class SpecificPricingExtension extends DataExtension
 {
-    private static $has_many = [
+    private static array $has_many = [
         'SpecificPrices' => SpecificPrice::class
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         if ($tab = $fields->fieldByName('Root.Pricing')) {
             $fields = $tab->Fields();
@@ -33,7 +33,7 @@ class SpecificPricingExtension extends DataExtension
         }
     }
 
-    public function updateSellingPrice(&$price)
+    public function updateSellingPrice(&$price): void
     {
         $list = $this->owner->SpecificPrices()->filter( array('Price:LessThan' => $price ));
 

--- a/src/Extensions/SpecificPricingExtension.php
+++ b/src/Extensions/SpecificPricingExtension.php
@@ -35,11 +35,11 @@ class SpecificPricingExtension extends DataExtension
 
     public function updateSellingPrice(&$price): void
     {
-        $list = $this->owner->SpecificPrices()->filter( array('Price:LessThan' => $price ));
+        $list = $this->owner->SpecificPrices()->filter(['Price:LessThan' => $price ]);
 
         if ($list->exists() && $specificprice = SpecificPrice::filter(
             $list,
-                Security::getCurrentUser()
+            Security::getCurrentUser()
         )->first()
         ) {
             if ($specificprice->Price > 0) {

--- a/src/Extensions/SpecificPricingExtension.php
+++ b/src/Extensions/SpecificPricingExtension.php
@@ -20,14 +20,14 @@ class SpecificPricingExtension extends Extension
         'SpecificPrices' => SpecificPrice::class
     ];
 
-    public function updateCMSFields(FieldList $fields): void
+    public function updateCMSFields(FieldList $fieldList): void
     {
-        if ($tab = $fields->fieldByName('Root.Pricing')) {
-            $fields = $tab->Fields();
+        if ($tab = $fieldList->fieldByName('Root.Pricing')) {
+            $fieldList = $tab->Fields();
         }
 
-        if ($this->owner->isInDB() && ($fields->fieldByName('BasePrice') || $fields->fieldByName('Price'))) {
-            $fields->push(
+        if ($this->owner->isInDB() && ($fieldList->fieldByName('BasePrice') || $fieldList->fieldByName('Price'))) {
+            $fieldList->push(
                 GridField::create(
                     'SpecificPrices',
                     'Specific Prices',
@@ -40,10 +40,10 @@ class SpecificPricingExtension extends Extension
 
     public function updateSellingPrice(&$price): void
     {
-        $list = $this->owner->SpecificPrices()->filter(['Price:LessThan' => $price ]);
+        $hasManyList = $this->owner->SpecificPrices()->filter(['Price:LessThan' => $price ]);
 
-        if ($list->exists() && $specificprice = SpecificPrice::filter(
-            $list,
+        if ($hasManyList->exists() && $specificprice = SpecificPrice::filter(
+            $hasManyList,
             Security::getCurrentUser()
         )->first()
         ) {

--- a/src/Form/CouponForm.php
+++ b/src/Form/CouponForm.php
@@ -30,9 +30,7 @@ class CouponForm extends Form
 
         $fields = $this->config->getFormFields();
 
-        $actions = new FieldList(
-            FormAction::create('applyCoupon', _t('ApplyCoupon', 'Apply coupon'))
-        );
+        $actions = FieldList::create(FormAction::create('applyCoupon', _t('ApplyCoupon', 'Apply coupon')));
 
         parent::__construct($controller, $name, $fields, $actions, $validator);
 

--- a/src/Form/CouponForm.php
+++ b/src/Form/CouponForm.php
@@ -63,7 +63,7 @@ class CouponForm extends Form
 
         $order = $this->config->getOrder();
 
-        if ($order) {
+        if ($order->exists()) {
             $order->removeDiscounts();
         }
 

--- a/src/Form/CouponForm.php
+++ b/src/Form/CouponForm.php
@@ -2,6 +2,8 @@
 
 namespace SilverShop\Discounts\Form;
 
+use SilverStripe\Control\RequestHandler;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Forms\Form;
 use SilverShop\Model\Order;
 use SilverShop\Checkout\CheckoutComponentConfig;
@@ -17,9 +19,9 @@ use SilverShop\Forms\CheckoutComponentValidator;
  */
 class CouponForm extends Form
 {
-    protected $config;
+    protected CheckoutComponentConfig $config;
 
-    public function __construct($controller, $name, Order $order)
+    public function __construct(RequestHandler $controller, $name, Order $order)
     {
         $this->config = new CheckoutComponentConfig($order, false);
         $this->config->addComponent($couponcompoent = new CouponCheckoutComponent());
@@ -49,7 +51,7 @@ class CouponForm extends Form
         $controller->extend('updateCouponForm', $this, $order);
     }
 
-    public function applyCoupon($data, $form)
+    public function applyCoupon($data, $form): HTTPResponse
     {
         // form validation has passed by this point, so we can save data
         $this->config->setData($form->getData());
@@ -57,7 +59,7 @@ class CouponForm extends Form
         return $this->controller->redirectBack();
     }
 
-    public function removeCoupon($data, $form)
+    public function removeCoupon($data, $form): HTTPResponse
     {
         Controller::curr()->getRequest()->getSession()->clear('cart.couponcode');
 

--- a/src/Form/CouponForm.php
+++ b/src/Form/CouponForm.php
@@ -23,8 +23,8 @@ class CouponForm extends Form
 
     public function __construct(RequestHandler $requestHandler, $name, Order $order)
     {
-        $this->config = new CheckoutComponentConfig($order, false);
-        $this->config->addComponent($couponCheckoutComponent = new CouponCheckoutComponent());
+        $this->config = CheckoutComponentConfig::create($order, false);
+        $this->config->addComponent($couponCheckoutComponent = CouponCheckoutComponent::create());
 
         $checkoutComponentValidator = Injector::inst()->create(CheckoutComponentValidator::class, $this->config);
 

--- a/src/Form/CouponForm.php
+++ b/src/Form/CouponForm.php
@@ -21,22 +21,22 @@ class CouponForm extends Form
 {
     protected CheckoutComponentConfig $config;
 
-    public function __construct(RequestHandler $controller, $name, Order $order)
+    public function __construct(RequestHandler $requestHandler, $name, Order $order)
     {
         $this->config = new CheckoutComponentConfig($order, false);
-        $this->config->addComponent($couponcompoent = new CouponCheckoutComponent());
+        $this->config->addComponent($couponCheckoutComponent = new CouponCheckoutComponent());
 
-        $validator = Injector::inst()->create(CheckoutComponentValidator::class, $this->config);
+        $checkoutComponentValidator = Injector::inst()->create(CheckoutComponentValidator::class, $this->config);
 
-        $fields = $this->config->getFormFields();
+        $fieldList = $this->config->getFormFields();
 
         $actions = FieldList::create(FormAction::create('applyCoupon', _t('ApplyCoupon', 'Apply coupon')));
 
-        parent::__construct($controller, $name, $fields, $actions, $validator);
+        parent::__construct($requestHandler, $name, $fieldList, $actions, $checkoutComponentValidator);
 
         $this->loadDataFrom($this->config->getData(), Form::MERGE_IGNORE_FALSEISH);
 
-        $storeddata = $couponcompoent->getData($order);
+        $storeddata = $couponCheckoutComponent->getData($order);
 
         if (isset($storeddata['Code'])) {
             $actions->push(
@@ -46,7 +46,7 @@ class CouponForm extends Form
 
         $order = $this->config->getOrder();
 
-        $controller->extend('updateCouponForm', $this, $order);
+        $requestHandler->extend('updateCouponForm', $this, $order);
     }
 
     public function applyCoupon($data, $form): HTTPResponse

--- a/src/Form/GiftVoucherFormValidator.php
+++ b/src/Form/GiftVoucherFormValidator.php
@@ -6,7 +6,7 @@ use SilverStripe\Forms\RequiredFields;
 
 class GiftVoucherFormValidator extends RequiredFields
 {
-    public function php($data)
+    public function php($data): bool
     {
         $valid =  parent::php($data);
 
@@ -30,7 +30,8 @@ class GiftVoucherFormValidator extends RequiredFields
                 if ($giftvalue <= 0) {
                     $this->validationError(
                         'UnitPrice',
-                        'Gift value must be greater than 0');
+                        'Gift value must be greater than 0'
+                    );
                     return false;
                 }
             }

--- a/src/Form/GiftVoucherFormValidator.php
+++ b/src/Form/GiftVoucherFormValidator.php
@@ -27,6 +27,7 @@ class GiftVoucherFormValidator extends RequiredFields
                     );
                     return false;
                 }
+
                 if ($giftvalue <= 0) {
                     $this->validationError(
                         'UnitPrice',

--- a/src/Form/GridField_LinkComponent.php
+++ b/src/Form/GridField_LinkComponent.php
@@ -6,11 +6,11 @@ use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 
 class GridField_LinkComponent implements GridField_HTMLProvider
 {
-    protected $title;
-    protected $url;
-    protected $extraclasses;
+    protected string $title = '';
+    protected string $url = '';
+    protected string $extraclasses = '';
 
-    public function __construct($title, $url)
+    public function __construct(string $title, string $url)
     {
         $this->title = $title;
         $this->url = $url;
@@ -23,7 +23,7 @@ class GridField_LinkComponent implements GridField_HTMLProvider
         ];
     }
 
-    public function addExtraClass($classes)
+    public function addExtraClass(string $classes): void
     {
         $this->extraclasses = $classes;
     }

--- a/src/Form/GridField_LinkComponent.php
+++ b/src/Form/GridField_LinkComponent.php
@@ -7,7 +7,9 @@ use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 class GridField_LinkComponent implements GridField_HTMLProvider
 {
     protected string $title = '';
+
     protected string $url = '';
+
     protected string $extraclasses = '';
 
     public function __construct(string $title, string $url)
@@ -19,7 +21,7 @@ class GridField_LinkComponent implements GridField_HTMLProvider
     public function getHTMLFragments($gridField)
     {
         return [
-            'before' => "<a href=\"$this->url\" class=\"ss-ui-button $this->extraclasses\">$this->title</a>"
+            'before' => sprintf('<a href="%s" class="ss-ui-button %s">%s</a>', $this->url, $this->extraclasses, $this->title)
         ];
     }
 

--- a/src/ItemPriceInfo.php
+++ b/src/ItemPriceInfo.php
@@ -9,9 +9,9 @@ use SilverShop\Model\OrderItem;
  */
 class ItemPriceInfo extends PriceInfo
 {
-    protected $item;
+    protected OrderItem $item;
 
-    protected $quantity;
+    protected int|float $quantity = 0;
 
     public function __construct(OrderItem $item)
     {
@@ -25,22 +25,22 @@ class ItemPriceInfo extends PriceInfo
         parent::__construct($originalprice);
     }
 
-    public function getItem()
+    public function getItem(): OrderItem
     {
         return $this->item;
     }
 
-    public function getQuantity()
+    public function getQuantity(): int|float
     {
         return $this->quantity;
     }
 
-    public function getOriginalTotal()
+    public function getOriginalTotal(): int|float
     {
         return $this->originalprice * $this->quantity;
     }
 
-    public function debug()
+    public function debug(): string
     {
         $discount = $this->getBestDiscount();
         $total = $discount * $this->getQuantity();

--- a/src/ItemPriceInfo.php
+++ b/src/ItemPriceInfo.php
@@ -44,7 +44,7 @@ class ItemPriceInfo extends PriceInfo
     {
         $discount = $this->getBestDiscount();
         $total = $discount * $this->getQuantity();
-        $val = 'item: ' . $this->getItem()->TableTitle();
+        $val = 'item: ' . $this->getItem()->getTableTitle();
         $price = $this->getOriginalPrice();
         $val .= " price:{$price} discount:{$discount} total:{$total}.\n";
 

--- a/src/ItemPriceInfo.php
+++ b/src/ItemPriceInfo.php
@@ -44,12 +44,12 @@ class ItemPriceInfo extends PriceInfo
     {
         $discount = $this->getBestDiscount();
         $total = $discount * $this->getQuantity();
-        $val = 'item: ' .$this->getItem()->TableTitle();
+        $val = 'item: ' . $this->getItem()->TableTitle();
         $price = $this->getOriginalPrice();
         $val .= " price:$price discount:$discount total:$total.\n";
 
         if ($best = $this->getBestAdjustment()) {
-            $val .= $this->getBestAdjustment(). ' ';
+            $val .= $this->getBestAdjustment() . ' ';
             $val .= $this->getBestAdjustment()->getAdjuster()->Title;
         } else {
             $val .= 'No adjustments';

--- a/src/ItemPriceInfo.php
+++ b/src/ItemPriceInfo.php
@@ -48,7 +48,7 @@ class ItemPriceInfo extends PriceInfo
         $price = $this->getOriginalPrice();
         $val .= " price:$price discount:$discount total:$total.\n";
 
-        if ($best = $this->getBestAdjustment()) {
+        if (($best = $this->getBestAdjustment()) instanceof Adjustment) {
             $val .= $this->getBestAdjustment() . ' ';
             $val .= $this->getBestAdjustment()->getAdjuster()->Title;
         } else {

--- a/src/ItemPriceInfo.php
+++ b/src/ItemPriceInfo.php
@@ -13,14 +13,14 @@ class ItemPriceInfo extends PriceInfo
 
     protected int|float $quantity = 0;
 
-    public function __construct(OrderItem $item)
+    public function __construct(OrderItem $orderItem)
     {
-        $this->item = $item;
-        $this->quantity = $item->Quantity;
+        $this->item = $orderItem;
+        $this->quantity = $orderItem->Quantity;
 
-        $originalprice = $item->hasMethod('DiscountableAmount') ?
-                            $item->DiscountableAmount() :
-                            $item->UnitPrice();
+        $originalprice = $orderItem->hasMethod('DiscountableAmount') ?
+                            $orderItem->DiscountableAmount() :
+                            $orderItem->UnitPrice();
 
         parent::__construct($originalprice);
     }

--- a/src/ItemPriceInfo.php
+++ b/src/ItemPriceInfo.php
@@ -46,7 +46,7 @@ class ItemPriceInfo extends PriceInfo
         $total = $discount * $this->getQuantity();
         $val = 'item: ' . $this->getItem()->TableTitle();
         $price = $this->getOriginalPrice();
-        $val .= " price:$price discount:$discount total:$total.\n";
+        $val .= " price:{$price} discount:{$discount} total:{$total}.\n";
 
         if (($best = $this->getBestAdjustment()) instanceof Adjustment) {
             $val .= $this->getBestAdjustment() . ' ';
@@ -57,8 +57,7 @@ class ItemPriceInfo extends PriceInfo
 
         $val .= "\n";
         $val .= implode(',', $this->getAdjustments());
-        $val .= "\n\n";
 
-        return $val;
+        return $val . "\n\n";
     }
 }

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -127,9 +127,6 @@ class Discount extends DataObject implements PermissionProvider
      */
     private static int $unpaid_use_timeout = 10;
 
-    /**
-     * @return array
-     */
     public function getConstraints(): array
     {
         $extensions = $this->getExtensionInstances();
@@ -498,6 +495,7 @@ class Discount extends DataObject implements PermissionProvider
         if ($this->ForCart) {
             return 'Cart';
         }
+
         return null;
     }
 
@@ -525,11 +523,11 @@ class Discount extends DataObject implements PermissionProvider
 
         if ($includeunpaid) {
             $minutes = self::config()->unpaid_use_timeout;
-            $timeouttime = date('Y-m-d H:i:s', strtotime("-{$minutes} minutes"));
+            $timeouttime = date('Y-m-d H:i:s', strtotime(sprintf('-%s minutes', $minutes)));
             $orders = $orders->leftJoin('Omnipay_Payment', '"Omnipay_Payment"."OrderID" = "SilverShop_Order"."ID"')
                 ->where(
                     '("SilverShop_Order"."Paid" IS NOT NULL) OR ' .
-                        "(\"Omnipay_Payment\".\"Created\" > '$timeouttime' AND \"Omnipay_Payment\".\"Status\" NOT IN('Refunded', 'Void'))"
+                        sprintf("(\"Omnipay_Payment\".\"Created\" > '%s' AND \"Omnipay_Payment\".\"Status\" NOT IN('Refunded', 'Void'))", $timeouttime)
                 );
         } else {
             $orders = $orders->where('"SilverShop_Order"."Paid" IS NOT NULL');
@@ -643,7 +641,6 @@ class Discount extends DataObject implements PermissionProvider
      * @deprecated
      * @param      $order
      * @param      array $context
-     * @return     bool
      */
     public function valid(Order $order, $context = []): bool
     {

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -428,9 +428,9 @@ class Discount extends DataObject implements PermissionProvider
     /**
      * Get discounting amount
      */
-    public function getAmount()
+    public function getAmount(): float
     {
-        $amount = $this->getField('Amount');
+        $amount = (float) $this->getField('Amount');
 
         $this->extend('updateAmount', $amount);
 
@@ -587,8 +587,8 @@ class Discount extends DataObject implements PermissionProvider
                 'SilverShop_OrderItem_Discounts',
                 '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderItem_Discounts"."SilverShop_OrderItemID"'
             )
-            ->filter('SilverShop_OrderItem_Discounts.DiscountID', $this->ID)
-            ->filter('OrderAttribute.OrderID', $order->ID)
+            ->filter('SilverShop_DiscountID', $this->ID)
+            ->filter('OrderID', $order->ID)
             ->sum('DiscountAmount');
 
         $modifiersavings = OrderAttribute::get()
@@ -596,8 +596,8 @@ class Discount extends DataObject implements PermissionProvider
                 'SilverShop_OrderDiscountModifier_Discounts',
                 '"SilverShop_OrderAttribute"."ID" = "SilverShop_OrderDiscountModifier_Discounts"."SilverShop_OrderDiscountModifierID"'
             )
-            ->filter('SilverShop_OrderDiscountModifier_Discounts.DiscountID', $this->ID)
-            ->filter('OrderAttribute.OrderID', $order->ID)
+            ->filter('SilverShop_DiscountID', $this->ID)
+            ->filter('OrderID', $order->ID)
             ->sum('DiscountAmount');
 
         return $itemsavings + $modifiersavings;

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -134,7 +134,7 @@ class Discount extends DataObject implements PermissionProvider
 
         foreach ($extensions as $extension) {
             if ($extension instanceof DiscountConstraint) {
-                $output[] = get_class($extension);
+                $output[] = $extension::class;
             }
         }
 

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -58,16 +58,16 @@ use SilverStripe\ORM\Search\SearchContext;
  * @property bool $ForCart
  * @property bool $ForShipping
  * @property float $MaxAmount
- * @method ManyManyList<OrderItem> OrderItems()
- * @method ManyManyList<OrderDiscountModifier> DiscountModifiers()
- * @mixin CategoriesDiscountConstraint
- * @mixin ProductsDiscountConstraint
- * @mixin GroupDiscountConstraint
- * @mixin MembershipDiscountConstraint
- * @mixin DatetimeDiscountConstraint
- * @mixin ValueDiscountConstraint
- * @mixin UseLimitDiscountConstraint
- * @mixin CodeDiscountConstraint
+ * @method   ManyManyList<OrderItem> OrderItems()
+ * @method   ManyManyList<OrderDiscountModifier> DiscountModifiers()
+ * @mixin    CategoriesDiscountConstraint
+ * @mixin    ProductsDiscountConstraint
+ * @mixin    GroupDiscountConstraint
+ * @mixin    MembershipDiscountConstraint
+ * @mixin    DatetimeDiscountConstraint
+ * @mixin    ValueDiscountConstraint
+ * @mixin    UseLimitDiscountConstraint
+ * @mixin    CodeDiscountConstraint
  */
 class Discount extends DataObject implements PermissionProvider
 {
@@ -180,35 +180,52 @@ class Discount extends DataObject implements PermissionProvider
     public function getCMSFields($params = null)
     {
         //fields that shouldn't be changed once coupon is used
-        $fieldList = FieldList::create([
-            TabSet::create('Root', Tab::create('Main', TextField::create('Title'), CheckboxField::create('Active', 'Active')
-                ->setDescription('Enable/disable all use of this discount.'), HeaderField::create('ActionTitle', 'Action', 3), $typefield = SelectionGroup::create(
-                'Type',
-                [
-                    SelectionGroup_Item::create('Percent', $percentgroup = FieldGroup::create(
-                        $percentfield = NumericField::create('Percent', 'Percentage', '0.00')
-                            ->setScale(null)
-                            ->setDescription('e.g. 0.05 = 5%, 0.5 = 50%, and 5 = 500%'),
-                        $maxamountfield = CurrencyField::create(
-                            'MaxAmount',
-                            _t('MaxAmount', 'Maximum Amount')
-                        )->setDescription(
-                            'The total allowable discount. 0 means unlimited.'
-                        )
-                    ), 'Discount by percentage'),
-                    SelectionGroup_Item::create('Amount', $amountfield = CurrencyField::create('Amount', 'Amount', '$0.00'), 'Discount by fixed amount')
-                ]
-            )->setTitle('Type'), OptionSetField::create(
-                'For',
-                'Applies to',
-                [
-                    'Order' => 'Entire order',
-                    'Cart' => 'Cart subtotal',
-                    'Shipping' => 'Shipping subtotal',
-                    'Items' => 'Each individual item'
-                ]
-            )), Tab::create('Constraints', TabSet::create('ConstraintsTabs', $general = Tab::create('General', 'General'))))
-        ]);
+        $fieldList = FieldList::create(
+            [
+            TabSet::create(
+                'Root',
+                Tab::create(
+                    'Main',
+                    TextField::create('Title'),
+                    CheckboxField::create('Active', 'Active')
+                    ->setDescription('Enable/disable all use of this discount.'),
+                    HeaderField::create('ActionTitle', 'Action', 3),
+                    SelectionGroup::create(
+                        'Type',
+                        [
+                            SelectionGroup_Item::create(
+                                'Percent',
+                                $percentgroup = FieldGroup::create(
+                                    $percentfield = NumericField::create('Percent', 'Percentage', '0.00')
+                                        ->setScale(null)
+                                        ->setDescription('e.g. 0.05 = 5%, 0.5 = 50%, and 5 = 500%'),
+                                    $maxamountfield = CurrencyField::create(
+                                        'MaxAmount',
+                                        _t('MaxAmount', 'Maximum Amount')
+                                    )->setDescription(
+                                        'The total allowable discount. 0 means unlimited.'
+                                    )
+                                ),
+                                'Discount by percentage'
+                            ),
+                            SelectionGroup_Item::create('Amount', $amountfield = CurrencyField::create('Amount', 'Amount', '$0.00'), 'Discount by fixed amount')
+                        ]
+                    )->setTitle('Type'),
+                    OptionSetField::create(
+                        'For',
+                        'Applies to',
+                        [
+                            'Order' => 'Entire order',
+                            'Cart' => 'Cart subtotal',
+                            'Shipping' => 'Shipping subtotal',
+                            'Items' => 'Each individual item'
+                        ]
+                    )
+                ),
+                Tab::create('Constraints', TabSet::create('ConstraintsTabs', $general = Tab::create('General', 'General')))
+            )
+            ]
+        );
 
         if (!$this->isInDB()) {
             $general->push(
@@ -453,20 +470,18 @@ class Discount extends DataObject implements PermissionProvider
 
     /**
      * Map the single 'For' to the For"X" boolean fields
-     *
-     * @param string $val
      */
-    public function setFor($val): void
+    public function setFor(string $val): void
     {
-        if (!$val) {
+        if ($val === '' || $val === '0') {
             return;
         }
 
         $map = [
-            'Items' => [1, 0, 0],
-            'Cart' => [0, 1, 0],
-            'Shipping' => [0, 0, 1],
-            'Order' => [0, 1, 1]
+            'Items' => [true, false, false],
+            'Cart' => [false, true, false],
+            'Shipping' => [false, false, true],
+            'Order' => [false, true, true]
         ];
 
         $mapping = $map[$val];

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -379,7 +379,7 @@ class Discount extends DataObject implements PermissionProvider
     /**
      * Works out the discount on a given value.
      */
-    public function getDiscountValue($value)
+    public function getDiscountValue($value): float
     {
         $discount = 0;
 
@@ -542,7 +542,7 @@ class Discount extends DataObject implements PermissionProvider
      * Get the total amount saved through the use of this discount,
      * accross all paid orders.
      */
-    public function getSavingsTotal(): float|int|array
+    public function getSavingsTotal(): float
     {
         $itemsavings = $this->OrderItems()
             ->innerJoin(

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -225,7 +225,7 @@ class Discount extends DataObject implements PermissionProvider
             );
         }
 
-        if ($count = $this->getUseCount()) {
+        if (($count = $this->getUseCount()) !== 0) {
             $useHeader = _t('Discount.USEHEADER', 'Use Count: {count}', ['count' => $count]);
 
             $fields->addFieldsToTab(
@@ -432,7 +432,7 @@ class Discount extends DataObject implements PermissionProvider
     {
         $used = $this->getAppliedOrders(true);
 
-        if ($orderID) {
+        if ($orderID !== null && $orderID !== 0) {
             $used = $used->exclude('ID', $orderID);
         }
 

--- a/src/Model/Discount.php
+++ b/src/Model/Discount.php
@@ -344,7 +344,7 @@ class Discount extends DataObject implements PermissionProvider
      */
     public function validateOrder(Order $order, array $context = []): bool
     {
-        if (empty($order)) {
+        if (!$order instanceof Order) {
             $this->error(_t('Discount.NOORDER', 'Order has not been started.'));
 
             return false;

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -104,7 +104,7 @@ class GiftVoucherOrderItem extends OrderItem
     public function sendVoucher(OrderCoupon $orderCoupon): bool
     {
         $from = Email::config()->admin_email;
-        $to = $this->Order()->getLatestEmail();
+        $to = $this->Order()->exists() ? $this->Order()->getLatestEmail() : '';
         $subject = _t('Order.GIFTVOUCHERSUBJECT', 'Gift voucher');
         $email = Email::create();
         $email->setFrom($from);

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -31,11 +31,11 @@ class GiftVoucherOrderItem extends OrderItem
         'UnitPrice'
     ];
 
+    private static string $table_name = 'SilverShop_GiftVoucherOrderItem';
+
     private static array $dependencies = [
         'Logger' => '%$' . LoggerInterface::class,
     ];
-
-    private static string $table_name = 'SilverShop_GiftVoucherOrderItem';
 
     protected LoggerInterface $logger;
 
@@ -122,11 +122,17 @@ class GiftVoucherOrderItem extends OrderItem
 
         try {
             $email->send();
-        } catch (TransportExceptionInterface $e) {
-            $this->logger->error('GiftVoucherOrderItem.sendVoucher: error sending email in ' . __FILE__ . ' line ' . __LINE__ . ": {$e->getMessage()}");
+        } catch (TransportExceptionInterface $transportException) {
+            $this->logger->error('GiftVoucherOrderItem.sendVoucher: error sending email in ' . __FILE__ . ' line ' . __LINE__ . (': ' . $transportException->getMessage()));
             return false;
         }
 
         return true;
+    }
+
+    public function setLogger(LoggerInterface $logger): static
+    {
+        $this->logger = $logger;
+        return $this;
     }
 }

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -79,7 +79,7 @@ class GiftVoucherOrderItem extends OrderItem
             return false;
         }
 
-        $coupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => $this->Product()->Title,
             'Type' => 'Amount',
@@ -89,19 +89,19 @@ class GiftVoucherOrderItem extends OrderItem
             ]
         );
 
-        $this->extend('updateCreateCupon', $coupon);
+        $this->extend('updateCreateCupon', $orderCoupon);
 
-        $coupon->write();
+        $orderCoupon->write();
 
-        $this->Coupons()->add($coupon);
+        $this->Coupons()->add($orderCoupon);
 
-        return $coupon;
+        return $orderCoupon;
     }
 
     /*
      * Send the voucher to the appropriate email
      */
-    public function sendVoucher(OrderCoupon $coupon): bool
+    public function sendVoucher(OrderCoupon $orderCoupon): bool
     {
         $from = Email::config()->admin_email;
         $to = $this->Order()->getLatestEmail();
@@ -113,11 +113,11 @@ class GiftVoucherOrderItem extends OrderItem
         $email->setHTMLTemplate('GiftVoucherEmail');
         $email->setData(
             [
-                'Coupon' => $coupon
+                'Coupon' => $orderCoupon
             ]
         );
 
-        $this->extend('updateVoucherMail', $email, $coupon);
+        $this->extend('updateVoucherMail', $email, $orderCoupon);
 
         try {
             $email->send();

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -75,7 +75,7 @@ class GiftVoucherOrderItem extends OrderItem
      */
     public function createCoupon(): OrderCoupon|bool
     {
-        if (!$this->Product()) {
+        if (!$this->Product()->exists()) {
             return false;
         }
 

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -15,10 +15,6 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
  */
 class GiftVoucherOrderItem extends OrderItem
 {
-    /**
-     * @var LoggerInterface
-     */
-    public $Logger;
     private static array $db = [
         'GiftedTo' => 'Varchar'
     ];
@@ -37,7 +33,10 @@ class GiftVoucherOrderItem extends OrderItem
         'Logger' => '%$' . LoggerInterface::class,
     ];
 
-    protected LoggerInterface $logger;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * Don't get unit price from product

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -81,11 +81,11 @@ class GiftVoucherOrderItem extends OrderItem
 
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => $this->Product()->Title,
-            'Type' => 'Amount',
-            'Amount' => $this->UnitPrice,
-            'UseLimit' => 1,
-            'MinOrderValue' => $this->UnitPrice //safeguard that means coupons must be used entirely
+                'Title' => $this->Product()->Title,
+                'Type' => 'Amount',
+                'Amount' => $this->UnitPrice,
+                'UseLimit' => 1,
+                'MinOrderValue' => $this->UnitPrice //safeguard that means coupons must be used entirely
             ]
         );
 

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -15,6 +15,10 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
  */
 class GiftVoucherOrderItem extends OrderItem
 {
+    /**
+     * @var LoggerInterface
+     */
+    public $Logger;
     private static array $db = [
         'GiftedTo' => 'Varchar'
     ];

--- a/src/Model/GiftVoucherOrderItem.php
+++ b/src/Model/GiftVoucherOrderItem.php
@@ -2,12 +2,17 @@
 
 namespace SilverShop\Discounts\Model;
 
+use SilverStripe\ORM\HasManyList;
 use Psr\Log\LoggerInterface;
 use SilverStripe\ORM\ValidationException;
 use SilverShop\Model\Product\OrderItem;
 use SilverStripe\Control\Email\Email;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 
+/**
+ * @property ?string $GiftedTo
+ * @method   HasManyList<OrderCoupon> Coupons()
+ */
 class GiftVoucherOrderItem extends OrderItem
 {
     private static array $db = [
@@ -26,9 +31,9 @@ class GiftVoucherOrderItem extends OrderItem
         'Logger' => '%$' . LoggerInterface::class,
     ];
 
-    protected LoggerInterface $logger;
-
     private static string $table_name = 'SilverShop_GiftVoucherOrderItem';
+
+    protected LoggerInterface $logger;
 
     /**
      * Don't get unit price from product
@@ -71,7 +76,7 @@ class GiftVoucherOrderItem extends OrderItem
             return false;
         }
 
-        $coupon = new OrderCoupon(
+        $coupon = OrderCoupon::create(
             [
             'Title' => $this->Product()->Title,
             'Type' => 'Amount',

--- a/src/Model/Modifiers/OrderDiscountModifier.php
+++ b/src/Model/Modifiers/OrderDiscountModifier.php
@@ -88,9 +88,6 @@ class OrderDiscountModifier extends OrderModifier
         return $this->getUsedCodes();
     }
 
-    /**
-     * @return string
-     */
     public function getUsedCodes(): string
     {
         $discounts = $this->Order()->Discounts()->filter("Code:not", "");

--- a/src/Model/Modifiers/OrderDiscountModifier.php
+++ b/src/Model/Modifiers/OrderDiscountModifier.php
@@ -9,41 +9,41 @@ use SilverShop\Discounts\Calculator;
 
 class OrderDiscountModifier extends OrderModifier
 {
-    private static $subtitle_separator = ', ';
+    private static string $subtitle_separator = ', ';
 
-    private static $defaults = [
+    private static array $defaults = [
         'Type' => 'Deductable'
     ];
 
-    private static $many_many = [
+    private static array $many_many = [
         'Discounts' => Discount::class
     ];
 
-    private static $many_many_extraFields = [
+    private static array $many_many_extraFields = [
         'Discounts' => [
             'DiscountAmount' => 'Currency'
         ]
     ];
 
-    private static $singular_name = 'Discount';
+    private static string $singular_name = 'Discount';
 
-    private static $plural_name = 'Discounts';
+    private static string $plural_name = 'Discounts';
 
-    private static $table_name = 'SilverShop_OrderDiscountModifier';
+    private static string $table_name = 'SilverShop_OrderDiscountModifier';
 
-    private static $casting = [
+    private static array $casting = [
         'SubTitle' => 'HTMLFragment',
         'UsedCodes' => 'HTMLFragment'
     ];
 
-    public function value($incoming)
+    public function value($incoming): int|float
     {
         $this->Amount = $this->getDiscount();
 
         return $this->Amount;
     }
 
-    public function getDiscount()
+    public function getDiscount(): int|float
     {
         $context = [];
 
@@ -79,7 +79,7 @@ class OrderDiscountModifier extends OrderModifier
         return $code;
     }
 
-    public function getSubTitle()
+    public function getSubTitle(): string
     {
         return $this->getUsedCodes();
     }
@@ -87,7 +87,7 @@ class OrderDiscountModifier extends OrderModifier
     /**
      * @return string
      */
-    public function getUsedCodes()
+    public function getUsedCodes(): string
     {
         $discounts = $this->Order()->Discounts()->filter("Code:not", "");
 
@@ -101,7 +101,7 @@ class OrderDiscountModifier extends OrderModifier
         );
     }
 
-    public function ShowInTable()
+    public function ShowInTable(): bool
     {
         return $this->Amount > 0;
     }

--- a/src/Model/Modifiers/OrderDiscountModifier.php
+++ b/src/Model/Modifiers/OrderDiscountModifier.php
@@ -90,6 +90,10 @@ class OrderDiscountModifier extends OrderModifier
 
     public function getUsedCodes(): string
     {
+        if (!$this->Order()->exists()) {
+            return '';
+        }
+
         $discounts = $this->Order()->Discounts()->filter("Code:not", "");
 
         if (!$discounts->count()) {

--- a/src/Model/Modifiers/OrderDiscountModifier.php
+++ b/src/Model/Modifiers/OrderDiscountModifier.php
@@ -2,11 +2,15 @@
 
 namespace SilverShop\Discounts\Model\Modifiers;
 
+use SilverStripe\ORM\ManyManyList;
 use SilverShop\Model\Modifiers\OrderModifier;
 use SilverStripe\Control\Controller;
 use SilverShop\Discounts\Model\Discount;
 use SilverShop\Discounts\Calculator;
 
+/**
+ * @method ManyManyList<Discount> Discounts()
+ */
 class OrderDiscountModifier extends OrderModifier
 {
     private static string $subtitle_separator = ', ';

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -62,7 +62,7 @@ class OrderCoupon extends Discount
         $code = null;
         $generator = Injector::inst()->create(RandomGenerator::class);
         do {
-            $code = $prefix.strtoupper(substr($generator->randomToken(), 0, $length));
+            $code = $prefix . strtoupper(substr($generator->randomToken(), 0, $length));
         } while (self::get()->filter('Code:nocase', $code)->exists()
         );
 

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -9,6 +9,9 @@ use SilverStripe\Security\RandomGenerator;
 
 /**
  * Applies a discount to current order, if applicable, when entered at checkout.
+ * @property ?string $Code
+ * @property int $GiftVoucherID
+ * @method GiftVoucherOrderItem GiftVoucher()
  */
 class OrderCoupon extends Discount
 {

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -61,7 +61,7 @@ class OrderCoupon extends Discount
      */
     public static function generate_code(?int $length = null, string $prefix = ''): string
     {
-        $length = $length ?: self::config()->generated_code_length;
+        $length = $length !== null && $length !== 0 ? $length : self::config()->generated_code_length;
         $code = null;
         $generator = Injector::inst()->create(RandomGenerator::class);
         do {
@@ -151,7 +151,7 @@ class OrderCoupon extends Discount
 
     public function canDelete($member = null): bool
     {
-        if ($this->getUseCount()) {
+        if ($this->getUseCount() !== 0) {
             return false;
         }
 

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -98,7 +98,7 @@ class OrderCoupon extends Discount
         $minLength = self::config()->minimum_code_length;
         $code = $this->getField('Code');
 
-        if ($minLength && $code && $this->isChanged('Code') && strlen($code) < $minLength) {
+        if ($minLength && $code && $this->isChanged('Code') && strlen((string) $code) < $minLength) {
             $validationResult->addError(
                 _t(
                     'OrderCoupon.INVALIDMINLENGTH',
@@ -132,7 +132,7 @@ class OrderCoupon extends Discount
     public function setCode($code): static
     {
         if ($code) {
-            $code = trim(preg_replace('/[^0-9a-zA-Z]+/', '', $code));
+            $code = trim((string) preg_replace('/[^0-9a-zA-Z]+/', '', (string) $code));
             $this->setField('Code', strtoupper($code));
         }
 

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -83,7 +83,7 @@ class OrderCoupon extends Discount
             ],
             'Active'
         );
-        if ($this->owner->Code && $codefield) {
+        if ($this->owner->Code && $codefield->exists()) {
             $fieldList->replaceField(
                 'Code',
                 $codefield->performReadonlyTransformation()

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -12,20 +12,20 @@ use SilverStripe\Security\RandomGenerator;
  */
 class OrderCoupon extends Discount
 {
-    private static $db = [
+    private static array $db = [
         'Code' => 'Varchar(255)'
     ];
 
-    private static $has_one = [
+    private static array $has_one = [
         'GiftVoucher' => GiftVoucherOrderItem::class
     ];
 
-    private static $searchable_fields = [
+    private static array $searchable_fields = [
         'Title',
         'Code'
     ];
 
-    private static $summary_fields = [
+    private static array $summary_fields = [
         'Title',
         'Code',
         'DiscountNice' => 'Discount',
@@ -33,15 +33,15 @@ class OrderCoupon extends Discount
         'EndDate'
     ];
 
-    private static $singular_name = 'Coupon';
+    private static string $singular_name = 'Coupon';
 
-    private static $plural_name = 'Coupons';
+    private static string $plural_name = 'Coupons';
 
     private static $minimum_code_length = null;
 
-    private static $generated_code_length = 10;
+    private static int $generated_code_length = 10;
 
-    private static $table_name = 'SilverShop_OrderCoupon';
+    private static string $table_name = 'SilverShop_OrderCoupon';
 
     public static function get_by_code($code)
     {
@@ -53,13 +53,10 @@ class OrderCoupon extends Discount
     /**
      * Generates a unique code.
      *
-     * @todo   depending on the length, it may be possible that all the possible
+     * @todo depending on the length, it may be possible that all the possible
      *       codes have been generated.
-     * @param null $length
-     * @param string $prefix
-     * @return string the new code
      */
-    public static function generate_code($length = null, $prefix = '')
+    public static function generate_code(?int $length = null, string $prefix = ''): string
     {
         $length = $length ?: self::config()->generated_code_length;
         $code = null;
@@ -92,7 +89,7 @@ class OrderCoupon extends Discount
         return $fields;
     }
 
-    public function validate()
+    public function validate(): ValidationResult
     {
         $result = parent::validate();
         $minLength = self::config()->minimum_code_length;
@@ -113,7 +110,7 @@ class OrderCoupon extends Discount
         return $result;
     }
 
-    protected function onBeforeWrite()
+    protected function onBeforeWrite(): void
     {
         if (empty($this->Code)) {
             $this->Code = self::generate_code();
@@ -129,7 +126,7 @@ class OrderCoupon extends Discount
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         if ($code) {
             $code = trim(preg_replace('/[^0-9a-zA-Z]+/', '', $code));
@@ -139,17 +136,17 @@ class OrderCoupon extends Discount
         return $this;
     }
 
-    public function canView($member = null)
+    public function canView($member = null): bool
     {
         return true;
     }
 
-    public function canCreate($member = null, $context = [])
+    public function canCreate($member = null, $context = []): bool
     {
         return true;
     }
 
-    public function canDelete($member = null)
+    public function canDelete($member = null): bool
     {
         if ($this->getUseCount()) {
             return false;
@@ -158,7 +155,7 @@ class OrderCoupon extends Discount
         return true;
     }
 
-    public function canEdit($member = null)
+    public function canEdit($member = null): bool
     {
         if ($this->getUseCount() && !$this->Active) {
             return false;

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -63,9 +63,9 @@ class OrderCoupon extends Discount
     {
         $length = $length !== null && $length !== 0 ? $length : self::config()->generated_code_length;
         $code = null;
-        $generator = Injector::inst()->create(RandomGenerator::class);
+        $randomGenerator = Injector::inst()->create(RandomGenerator::class);
         do {
-            $code = $prefix . strtoupper(substr($generator->randomToken(), 0, $length));
+            $code = $prefix . strtoupper(substr($randomGenerator->randomToken(), 0, $length));
         } while (self::get()->filter('Code:nocase', $code)->exists()
         );
 
@@ -74,8 +74,8 @@ class OrderCoupon extends Discount
 
     public function getCMSFields($params = null)
     {
-        $fields = parent::getCMSFields();
-        $fields->addFieldsToTab(
+        $fieldList = parent::getCMSFields();
+        $fieldList->addFieldsToTab(
             'Root.Main',
             [
                 $codefield = TextField::create('Code')->setMaxLength(25),
@@ -83,23 +83,23 @@ class OrderCoupon extends Discount
             'Active'
         );
         if ($this->owner->Code && $codefield) {
-            $fields->replaceField(
+            $fieldList->replaceField(
                 'Code',
                 $codefield->performReadonlyTransformation()
             );
         }
 
-        return $fields;
+        return $fieldList;
     }
 
     public function validate(): ValidationResult
     {
-        $result = parent::validate();
+        $validationResult = parent::validate();
         $minLength = self::config()->minimum_code_length;
         $code = $this->getField('Code');
 
         if ($minLength && $code && $this->isChanged('Code') && strlen($code) < $minLength) {
-            $result->addError(
+            $validationResult->addError(
                 _t(
                     'OrderCoupon.INVALIDMINLENGTH',
                     'Coupon code must be at least {length} characters in length',
@@ -110,7 +110,7 @@ class OrderCoupon extends Discount
             );
         }
 
-        return $result;
+        return $validationResult;
     }
 
     protected function onBeforeWrite(): void

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -40,7 +40,7 @@ class OrderCoupon extends Discount
 
     private static string $plural_name = 'Coupons';
 
-    private static $minimum_code_length = null;
+    private static $minimum_code_length;
 
     private static int $generated_code_length = 10;
 
@@ -151,19 +151,11 @@ class OrderCoupon extends Discount
 
     public function canDelete($member = null): bool
     {
-        if ($this->getUseCount() !== 0) {
-            return false;
-        }
-
-        return true;
+        return $this->getUseCount() === 0;
     }
 
     public function canEdit($member = null): bool
     {
-        if ($this->getUseCount() && !$this->Active) {
-            return false;
-        }
-
-        return true;
+        return !($this->getUseCount() && !$this->Active);
     }
 }

--- a/src/Model/OrderCoupon.php
+++ b/src/Model/OrderCoupon.php
@@ -9,9 +9,10 @@ use SilverStripe\Security\RandomGenerator;
 
 /**
  * Applies a discount to current order, if applicable, when entered at checkout.
+ *
  * @property ?string $Code
  * @property int $GiftVoucherID
- * @method GiftVoucherOrderItem GiftVoucher()
+ * @method   GiftVoucherOrderItem GiftVoucher()
  */
 class OrderCoupon extends Discount
 {
@@ -124,15 +125,11 @@ class OrderCoupon extends Discount
 
     /**
      * Forces codes to be alpha-numeric, uppercase, and trimmed
-     *
-     * @param string
-     *
-     * @return $this
      */
-    public function setCode($code): static
+    public function setCode(string $code): static
     {
-        if ($code) {
-            $code = trim((string) preg_replace('/[^0-9a-zA-Z]+/', '', (string) $code));
+        if ($code !== '' && $code !== '0') {
+            $code = trim((string) preg_replace('/[^0-9a-zA-Z]+/', '', $code));
             $this->setField('Code', strtoupper($code));
         }
 

--- a/src/Model/OrderDiscount.php
+++ b/src/Model/OrderDiscount.php
@@ -2,7 +2,6 @@
 
 namespace SilverShop\Discounts\Model;
 
-
 /**
  * Order discounts.
  *
@@ -11,6 +10,5 @@ namespace SilverShop\Discounts\Model;
  */
 class OrderDiscount extends Discount
 {
-
-    private static $table_name = 'SilverShop_OrderDiscount';
+    private static string $table_name = 'SilverShop_OrderDiscount';
 }

--- a/src/Model/PartialUseDiscount.php
+++ b/src/Model/PartialUseDiscount.php
@@ -5,6 +5,12 @@ namespace SilverShop\Discounts\Model;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
 
+/**
+ * @property int $ChildID
+ * @method \SilverShop\Discounts\Model\PartialUseDiscount Child()
+ * @property int $ParentID
+ * @method \SilverShop\Discounts\Model\PartialUseDiscount Parent()
+ */
 class PartialUseDiscount extends Discount
 {
     private static array $has_one = [
@@ -95,7 +101,7 @@ class PartialUseDiscount extends Discount
     {
         $result = parent::validate();
         //prevent vital things from changing
-        foreach (self::$defaults as $field => $value) {
+        foreach ($this->config()->get('defaults') as $field => $value) {
             if ($this->isChanged($field)) {
                 $result->addError("$field should not be changed for partial use discounts.");
             }

--- a/src/Model/PartialUseDiscount.php
+++ b/src/Model/PartialUseDiscount.php
@@ -2,18 +2,20 @@
 
 namespace SilverShop\Discounts\Model;
 
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\ORM\ValidationResult;
 
 class PartialUseDiscount extends Discount
 {
-    private static $has_one = [
+    private static array $has_one = [
         'Parent' => PartialUseDiscount::class
     ];
 
-    private static $belongs_to = [
+    private static array $belongs_to = [
         'Child' => PartialUseDiscount::class
     ];
 
-    private static $defaults = [
+    private static array $defaults = [
         'Type' => 'Amount',
         'ForCart' => 1,
         'ForItems' => 0,
@@ -21,24 +23,28 @@ class PartialUseDiscount extends Discount
         'UseLimit' => 1
     ];
 
-    private static $singular_name = 'Partial Use Discount';
+    private static string $singular_name = 'Partial Use Discount';
 
-    private static $plural_name = 'Partial Use Discounts';
+    private static string $plural_name = 'Partial Use Discounts';
 
-    private static $table_name = 'SilverShop_PartialUseDiscount';
+    private static string $table_name = 'SilverShop_PartialUseDiscount';
 
     public function getCMSFields($params = null)
     {
-        $fields = parent::getCMSFields([
+        $fields = parent::getCMSFields(
+            [
             'forcetype' => 'Amount'
-        ]);
+            ]
+        );
 
-        $fields->removeByName([
+        $fields->removeByName(
+            [
             'ForCart',
             'ForItems',
             'ForShipping',
             'For'
-        ]);
+            ]
+        );
 
         $limitfield = $fields->dataFieldByName('UseLimit');
 
@@ -47,13 +53,12 @@ class PartialUseDiscount extends Discount
     }
 
     /**
-     * Create remainder discount object.
+     * Create remainder discount object.  Return new 'remainder' discount.
+     * $used the amount of this discount that was used up
      *
-     * @param  float $used the amount of this discount that was used up
-     * @return PartialUseDiscount  new 'remainder' discount
-     * @throws \SilverStripe\ORM\ValidationException
+     * @throws ValidationException
      */
-    public function createRemainder($used)
+    public function createRemainder(float $used): ?static
     {
         //don't recreate or do stuff with inactive discount
         if (!$this->Active || $this->Child()->exists()) {
@@ -86,7 +91,7 @@ class PartialUseDiscount extends Discount
         return $remainder;
     }
 
-    public function validate()
+    public function validate(): ValidationResult
     {
         $result = parent::validate();
         //prevent vital things from changing
@@ -102,7 +107,7 @@ class PartialUseDiscount extends Discount
     /**
      * Delete complex relations
      */
-    protected function deleteRelationships()
+    protected function deleteRelationships(): void
     {
         if ($this->manyMany()) {
             foreach ($this->manyMany() as $name => $type) {

--- a/src/Model/PartialUseDiscount.php
+++ b/src/Model/PartialUseDiscount.php
@@ -7,9 +7,9 @@ use SilverStripe\ORM\ValidationResult;
 
 /**
  * @property int $ChildID
- * @method \SilverShop\Discounts\Model\PartialUseDiscount Child()
+ * @method   \SilverShop\Discounts\Model\PartialUseDiscount Child()
  * @property int $ParentID
- * @method \SilverShop\Discounts\Model\PartialUseDiscount Parent()
+ * @method   \SilverShop\Discounts\Model\PartialUseDiscount Parent()
  */
 class PartialUseDiscount extends Discount
 {
@@ -37,18 +37,14 @@ class PartialUseDiscount extends Discount
 
     public function getCMSFields($params = null)
     {
-        $fieldList = parent::getCMSFields(
-            [
-            'forcetype' => 'Amount'
-            ]
-        );
+        $fieldList = parent::getCMSFields(['forcetype' => 'Amount']);
 
         $fieldList->removeByName(
             [
-            'ForCart',
-            'ForItems',
-            'ForShipping',
-            'For'
+                'ForCart',
+                'ForItems',
+                'ForShipping',
+                'For'
             ]
         );
 

--- a/src/Model/PartialUseDiscount.php
+++ b/src/Model/PartialUseDiscount.php
@@ -70,6 +70,7 @@ class PartialUseDiscount extends Discount
         if (!$this->Active || $this->Child()->exists()) {
             return null;
         }
+
         $remainder = null;
         //only create remainder if used less than amount
         $amount = $this->getAmount();
@@ -103,7 +104,7 @@ class PartialUseDiscount extends Discount
         //prevent vital things from changing
         foreach ($this->config()->get('defaults') as $field => $value) {
             if ($this->isChanged($field)) {
-                $result->addError("$field should not be changed for partial use discounts.");
+                $result->addError($field . ' should not be changed for partial use discounts.');
             }
         }
 

--- a/src/Model/PartialUseDiscount.php
+++ b/src/Model/PartialUseDiscount.php
@@ -37,13 +37,13 @@ class PartialUseDiscount extends Discount
 
     public function getCMSFields($params = null)
     {
-        $fields = parent::getCMSFields(
+        $fieldList = parent::getCMSFields(
             [
             'forcetype' => 'Amount'
             ]
         );
 
-        $fields->removeByName(
+        $fieldList->removeByName(
             [
             'ForCart',
             'ForItems',
@@ -52,10 +52,10 @@ class PartialUseDiscount extends Discount
             ]
         );
 
-        $limitfield = $fields->dataFieldByName('UseLimit');
+        $limitfield = $fieldList->dataFieldByName('UseLimit');
 
-        $fields->replaceField('UseLimit', $limitfield->performReadonlyTransformation());
-        return $fields;
+        $fieldList->replaceField('UseLimit', $limitfield->performReadonlyTransformation());
+        return $fieldList;
     }
 
     /**
@@ -100,15 +100,15 @@ class PartialUseDiscount extends Discount
 
     public function validate(): ValidationResult
     {
-        $result = parent::validate();
+        $validationResult = parent::validate();
         //prevent vital things from changing
         foreach ($this->config()->get('defaults') as $field => $value) {
             if ($this->isChanged($field)) {
-                $result->addError($field . ' should not be changed for partial use discounts.');
+                $validationResult->addError($field . ' should not be changed for partial use discounts.');
             }
         }
 
-        return $result;
+        return $validationResult;
     }
 
     /**

--- a/src/Model/PartialUseDiscount.php
+++ b/src/Model/PartialUseDiscount.php
@@ -81,7 +81,7 @@ class PartialUseDiscount extends Discount
             $remainder->deleteRelationships();
 
             // create proper new relationships
-            $this->duplicateManyManyRelations($this, $remainder, true);
+            $this->duplicateRelations($this, $remainder, $this->manyMany());
 
             //TODO: there may be some relationships that shouldn't be copied?
             $remainder->Amount = $amount - $used;

--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -5,6 +5,7 @@ namespace SilverShop\Discounts\Model;
 use SilverStripe\ORM\DataObject;
 use SilverShop\Page\Product;
 use SilverShop\Model\Variation\Variation;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Permission;
 use SilverStripe\ORM\DataList;
@@ -26,59 +27,59 @@ use SilverStripe\ORM\DataList;
  */
 class SpecificPrice extends DataObject
 {
-    private static $db = [
+    private static array $db = [
         'Price' => 'Currency',
         'DiscountPercent' => 'Percentage',
         'StartDate' => 'Date',
         'EndDate' => 'Date'
     ];
 
-    private static $has_one = [
+    private static array $has_one = [
         'Product' => Product::class,
         'ProductVariation' => Variation::class,
         'Group' => Group::class
     ];
 
-    private static $summary_fields = [
+    private static array $summary_fields = [
         'Price' => 'Price',
         'StartDate' => 'Start',
         'EndDate' => 'End',
         'Group.Code' => 'Group'
     ];
 
-    private static $default_sort = '"Price" ASC';
+    private static string $default_sort = '"Price" ASC';
 
-    private static $table_name = 'SilverShop_SpecificPrice';
+    private static string $table_name = 'SilverShop_SpecificPrice';
 
-    public function canView($member = null)
+    public function canView($member = null): bool
     {
         return
             parent::canView($member) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
-    public function canEdit($member = null)
+    public function canEdit($member = null): bool
     {
         return
             parent::canEdit($member) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
-    public function canCreate($member = null, $context = [])
+    public function canCreate($member = null, $context = []): bool
     {
         return
             parent::canCreate($member, $context) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
-    public function canDelete($member = null)
+    public function canDelete($member = null): bool
     {
         return
             parent::canDelete($member) ||
             Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
-    public static function filter(DataList $list, $member = null)
+    public static function filter(DataList $list, $member = null): DataList
     {
         $now = date('Y-m-d H:i:s');
         $nowminusone = date('Y-m-d H:i:s', strtotime('-1 day'));
@@ -99,7 +100,7 @@ class SpecificPrice extends DataObject
         return $list;
     }
 
-    public function getCMSFields()
+    public function getCMSFields(): FieldList
     {
         $fields = parent::getCMSFields();
         $fields->removeByName('ProductID');

--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -63,6 +63,7 @@ class SpecificPrice extends DataObject
         if (parent::canView($member)) {
             return true;
         }
+
         return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
@@ -71,6 +72,7 @@ class SpecificPrice extends DataObject
         if (parent::canEdit($member)) {
             return true;
         }
+
         return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
@@ -79,6 +81,7 @@ class SpecificPrice extends DataObject
         if (parent::canCreate($member, $context)) {
             return true;
         }
+
         return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
@@ -87,10 +90,11 @@ class SpecificPrice extends DataObject
         if (parent::canDelete($member)) {
             return true;
         }
+
         return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
-    public static function filter(DataList $list, $member = null): DataList
+    public static function filter(DataList $dataList, $member = null): DataList
     {
         $now = date('Y-m-d H:i:s');
         $nowminusone = date('Y-m-d H:i:s', strtotime('-1 day'));
@@ -100,7 +104,7 @@ class SpecificPrice extends DataObject
             $groupids = array_merge($member->Groups()->map('ID', 'ID')->toArray(), $groupids);
         }
 
-        $list = $list->where(
+        $dataList = $dataList->where(
             sprintf("(\"SilverShop_SpecificPrice\".\"StartDate\" IS NULL) OR (\"SilverShop_SpecificPrice\".\"StartDate\" < '%s')", $now)
         )
             ->where(
@@ -108,15 +112,15 @@ class SpecificPrice extends DataObject
             )
             ->filter('GroupID', $groupids);
 
-        return $list;
+        return $dataList;
     }
 
     public function getCMSFields(): FieldList
     {
-        $fields = parent::getCMSFields();
-        $fields->removeByName('ProductID');
-        $fields->removeByName('ProductVariationID');
+        $fieldList = parent::getCMSFields();
+        $fieldList->removeByName('ProductID');
+        $fieldList->removeByName('ProductVariationID');
 
-        return $fields;
+        return $fieldList;
     }
 }

--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -97,10 +97,10 @@ class SpecificPrice extends DataObject
         }
 
         $list = $list->where(
-            "(\"SilverShop_SpecificPrice\".\"StartDate\" IS NULL) OR (\"SilverShop_SpecificPrice\".\"StartDate\" < '$now')"
+            sprintf("(\"SilverShop_SpecificPrice\".\"StartDate\" IS NULL) OR (\"SilverShop_SpecificPrice\".\"StartDate\" < '%s')", $now)
         )
             ->where(
-                "(\"SilverShop_SpecificPrice\".\"EndDate\" IS NULL) OR (\"SilverShop_SpecificPrice\".\"EndDate\" > '$nowminusone')"
+                sprintf("(\"SilverShop_SpecificPrice\".\"EndDate\" IS NULL) OR (\"SilverShop_SpecificPrice\".\"EndDate\" > '%s')", $nowminusone)
             )
             ->filter('GroupID', $groupids);
 

--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -60,30 +60,34 @@ class SpecificPrice extends DataObject
 
     public function canView($member = null): bool
     {
-        return
-            parent::canView($member) ||
-            Permission::checkMember($member, 'MANAGE_DISCOUNTS');
+        if (parent::canView($member)) {
+            return true;
+        }
+        return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
     public function canEdit($member = null): bool
     {
-        return
-            parent::canEdit($member) ||
-            Permission::checkMember($member, 'MANAGE_DISCOUNTS');
+        if (parent::canEdit($member)) {
+            return true;
+        }
+        return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
     public function canCreate($member = null, $context = []): bool
     {
-        return
-            parent::canCreate($member, $context) ||
-            Permission::checkMember($member, 'MANAGE_DISCOUNTS');
+        if (parent::canCreate($member, $context)) {
+            return true;
+        }
+        return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
     public function canDelete($member = null): bool
     {
-        return
-            parent::canDelete($member) ||
-            Permission::checkMember($member, 'MANAGE_DISCOUNTS');
+        if (parent::canDelete($member)) {
+            return true;
+        }
+        return (bool) Permission::checkMember($member, 'MANAGE_DISCOUNTS');
     }
 
     public static function filter(DataList $list, $member = null): DataList

--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -24,6 +24,13 @@ use SilverStripe\ORM\DataList;
  * @method   Product Product()
  * @method   Variation ProductVariation()
  * @method   Group Group()
+ * @property float $Price
+ * @property float $DiscountPercent
+ * @property ?string $StartDate
+ * @property ?string $EndDate
+ * @property int $ProductID
+ * @property int $ProductVariationID
+ * @property int $GroupID
  */
 class SpecificPrice extends DataObject
 {

--- a/src/Model/SpecificPrice.php
+++ b/src/Model/SpecificPrice.php
@@ -13,17 +13,6 @@ use SilverStripe\ORM\DataList;
 /**
  * Represents a price change applied to a Product or ProductVariation, for a
  * period of time or for a specific group.
- *
- * @property float Price
- * @property float DiscountPercent
- * @property string StartDate
- * @property string EndDate
- * @property int ProductID
- * @property int ProductVariationID
- * @property int GroupID
- * @method   Product Product()
- * @method   Variation ProductVariation()
- * @method   Group Group()
  * @property float $Price
  * @property float $DiscountPercent
  * @property ?string $StartDate
@@ -31,6 +20,9 @@ use SilverStripe\ORM\DataList;
  * @property int $ProductID
  * @property int $ProductVariationID
  * @property int $GroupID
+ * @method Product Product()
+ * @method Variation ProductVariation()
+ * @method Group Group()
  */
 class SpecificPrice extends DataObject
 {

--- a/src/Page/GiftVoucherProduct.php
+++ b/src/Page/GiftVoucherProduct.php
@@ -65,10 +65,6 @@ class GiftVoucherProduct extends Product
             return false;
         }
 
-        if (!$this->isPublished()) {
-            return false;
-        }
-
-        return true;
+        return (bool) $this->isPublished();
     }
 }

--- a/src/Page/GiftVoucherProduct.php
+++ b/src/Page/GiftVoucherProduct.php
@@ -2,6 +2,7 @@
 
 namespace SilverShop\Discounts\Page;
 
+use SilverStripe\Forms\FieldList;
 use SilverShop\Discounts\Model\GiftVoucherOrderItem;
 use SilverShop\Page\Product;
 use SilverStripe\Forms\OptionsetField;
@@ -13,20 +14,20 @@ use SilverStripe\Forms\TextField;
  */
 class GiftVoucherProduct extends Product
 {
-    private static $db = [
+    private static array $db = [
         'VariableAmount' => 'Boolean',
         'MinimumAmount' => 'Currency'
     ];
 
-    private static $singular_name = 'Gift Voucher';
+    private static string $singular_name = 'Gift Voucher';
 
-    private static $plural_name = 'Gift Vouchers';
+    private static string $plural_name = 'Gift Vouchers';
 
-    private static $order_item = GiftVoucherOrderItem::class;
+    private static string $order_item = GiftVoucherOrderItem::class;
 
-    private static $table_name = 'SilverShop_GiftVoucherProduct';
+    private static string $table_name = 'SilverShop_GiftVoucherProduct';
 
-    public function getCMSFields()
+    public function getCMSFields(): FieldList
     {
         $fields = parent::getCMSFields();
         $fields->addFieldToTab(
@@ -35,8 +36,8 @@ class GiftVoucherProduct extends Product
                 'VariableAmount',
                 'Price',
                 [
-                0 => 'Fixed',
-                1 => 'Allow customer to choose'
+                    0 => 'Fixed',
+                    1 => 'Allow customer to choose'
                 ]
             ),
             'BasePrice'
@@ -45,8 +46,8 @@ class GiftVoucherProduct extends Product
         $fields->addFieldsToTab(
             'Root.Pricing',
             [
-            //text field, because of CMS js validation issue
-            $minimumamount = new TextField('MinimumAmount', 'Minimum Amount')
+                //text field, because of CMS js validation issue
+                TextField::create('MinimumAmount', 'Minimum Amount')
             ]
         );
 
@@ -56,7 +57,7 @@ class GiftVoucherProduct extends Product
         return $fields;
     }
 
-    public function canPurchase($member = null, $quantity = 1)
+    public function canPurchase($member = null, $quantity = 1): bool
     {
         if (!self::config()->get('global_allow_purchase')) {
             return false;

--- a/src/Page/GiftVoucherProduct.php
+++ b/src/Page/GiftVoucherProduct.php
@@ -11,6 +11,8 @@ use SilverStripe\Forms\TextField;
 /**
  * Gift voucher products, when purchased will send out a voucher code to the
  * customer via email.
+ * @property bool $VariableAmount
+ * @property float $MinimumAmount
  */
 class GiftVoucherProduct extends Product
 {
@@ -32,14 +34,10 @@ class GiftVoucherProduct extends Product
         $fields = parent::getCMSFields();
         $fields->addFieldToTab(
             'Root.Pricing',
-            new OptionsetField(
-                'VariableAmount',
-                'Price',
-                [
-                    0 => 'Fixed',
-                    1 => 'Allow customer to choose'
-                ]
-            ),
+            OptionsetField::create('VariableAmount', 'Price', [
+                0 => 'Fixed',
+                1 => 'Allow customer to choose'
+            ]),
             'BasePrice'
         );
 

--- a/src/Page/GiftVoucherProduct.php
+++ b/src/Page/GiftVoucherProduct.php
@@ -31,8 +31,8 @@ class GiftVoucherProduct extends Product
 
     public function getCMSFields(): FieldList
     {
-        $fields = parent::getCMSFields();
-        $fields->addFieldToTab(
+        $fieldList = parent::getCMSFields();
+        $fieldList->addFieldToTab(
             'Root.Pricing',
             OptionsetField::create('VariableAmount', 'Price', [
                 0 => 'Fixed',
@@ -41,7 +41,7 @@ class GiftVoucherProduct extends Product
             'BasePrice'
         );
 
-        $fields->addFieldsToTab(
+        $fieldList->addFieldsToTab(
             'Root.Pricing',
             [
                 //text field, because of CMS js validation issue
@@ -49,10 +49,10 @@ class GiftVoucherProduct extends Product
             ]
         );
 
-        $fields->removeByName('CostPrice');
-        $fields->removeByName('Variations');
-        $fields->removeByName('Model');
-        return $fields;
+        $fieldList->removeByName('CostPrice');
+        $fieldList->removeByName('Variations');
+        $fieldList->removeByName('Model');
+        return $fieldList;
     }
 
     public function canPurchase($member = null, $quantity = 1): bool

--- a/src/Page/GiftVoucherProduct.php
+++ b/src/Page/GiftVoucherProduct.php
@@ -11,6 +11,7 @@ use SilverStripe\Forms\TextField;
 /**
  * Gift voucher products, when purchased will send out a voucher code to the
  * customer via email.
+ *
  * @property bool $VariableAmount
  * @property float $MinimumAmount
  */
@@ -34,10 +35,14 @@ class GiftVoucherProduct extends Product
         $fieldList = parent::getCMSFields();
         $fieldList->addFieldToTab(
             'Root.Pricing',
-            OptionsetField::create('VariableAmount', 'Price', [
-                0 => 'Fixed',
-                1 => 'Allow customer to choose'
-            ]),
+            OptionsetField::create(
+                'VariableAmount',
+                'Price',
+                [
+                    0 => 'Fixed',
+                    1 => 'Allow customer to choose'
+                ]
+            ),
             'BasePrice'
         );
 

--- a/src/Page/GiftVoucherProductController.php
+++ b/src/Page/GiftVoucherProductController.php
@@ -7,9 +7,6 @@ use SilverShop\Page\ProductController;
 use SilverStripe\Forms\CurrencyField;
 use SilverStripe\Forms\Form;
 
-/**
- * @extends ProductController<GiftVoucherProduct>
- */
 class GiftVoucherProductController extends ProductController
 {
     private static array $allowed_actions = [
@@ -21,11 +18,7 @@ class GiftVoucherProductController extends ProductController
         $form = parent::Form();
 
         if ($this->VariableAmount) {
-            $form->setSaveableFields(
-                [
-                    'UnitPrice'
-                ]
-            );
+            $form->setSaveableFields(['UnitPrice']);
             $form->Fields()->push(
                 $giftamount = CurrencyField::create('UnitPrice', _t('GiftVoucherProduct.Amount', 'Amount'), $this->BasePrice)
             );
@@ -33,10 +26,10 @@ class GiftVoucherProductController extends ProductController
         }
 
         $form->setValidator(
-            $giftVoucherFormValidator = new GiftVoucherFormValidator(
+            $giftVoucherFormValidator = GiftVoucherFormValidator::create(
                 [
-                'Quantity',
-                'UnitPrice'
+                    'Quantity',
+                    'UnitPrice'
                 ]
             )
         );

--- a/src/Page/GiftVoucherProductController.php
+++ b/src/Page/GiftVoucherProductController.php
@@ -31,6 +31,7 @@ class GiftVoucherProductController extends ProductController
             );
             $giftamount->setForm($form);
         }
+
         $form->setValidator(
             $validator = new GiftVoucherFormValidator(
                 [

--- a/src/Page/GiftVoucherProductController.php
+++ b/src/Page/GiftVoucherProductController.php
@@ -33,7 +33,7 @@ class GiftVoucherProductController extends ProductController
         }
 
         $form->setValidator(
-            $validator = new GiftVoucherFormValidator(
+            $giftVoucherFormValidator = new GiftVoucherFormValidator(
                 [
                 'Quantity',
                 'UnitPrice'

--- a/src/Page/GiftVoucherProductController.php
+++ b/src/Page/GiftVoucherProductController.php
@@ -5,14 +5,15 @@ namespace SilverShop\Discounts\Page;
 use SilverShop\Discounts\Form\GiftVoucherFormValidator;
 use SilverShop\Page\ProductController;
 use SilverStripe\Forms\CurrencyField;
+use SilverStripe\Forms\Form;
 
 class GiftVoucherProductController extends ProductController
 {
-    private static $allowed_actions = [
+    private static array $allowed_actions = [
         'Form'
     ];
 
-    public function Form()
+    public function Form(): Form
     {
         $form = parent::Form();
 
@@ -31,7 +32,7 @@ class GiftVoucherProductController extends ProductController
             $validator = new GiftVoucherFormValidator(
                 [
                 'Quantity',
-            'UnitPrice'
+                'UnitPrice'
                 ]
             )
         );

--- a/src/Page/GiftVoucherProductController.php
+++ b/src/Page/GiftVoucherProductController.php
@@ -7,6 +7,9 @@ use SilverShop\Page\ProductController;
 use SilverStripe\Forms\CurrencyField;
 use SilverStripe\Forms\Form;
 
+/**
+ * @extends ProductController<GiftVoucherProduct>
+ */
 class GiftVoucherProductController extends ProductController
 {
     private static array $allowed_actions = [

--- a/src/PriceInfo.php
+++ b/src/PriceInfo.php
@@ -17,7 +17,8 @@ class PriceInfo
 
     public function __construct(int|float $price)
     {
-        $this->currentprice = $this->originalprice = $price;
+        $this->currentprice = $price;
+        $this->originalprice = $price;
     }
 
     public function getOriginalPrice(): int|float
@@ -47,6 +48,7 @@ class PriceInfo
         if ($this->bestadjustment instanceof Adjustment) {
             return $this->bestadjustment->getValue();
         }
+
         return 0;
     }
 

--- a/src/PriceInfo.php
+++ b/src/PriceInfo.php
@@ -13,7 +13,7 @@ class PriceInfo
 
     protected array $adjustments = [];
 
-    protected ?Adjustment $bestadjustment;
+    protected ?Adjustment $bestadjustment = null;
 
     public function __construct(int|float $price)
     {

--- a/src/PriceInfo.php
+++ b/src/PriceInfo.php
@@ -31,11 +31,11 @@ class PriceInfo
         return $this->currentprice;
     }
 
-    public function adjustPrice(Adjustment $a): void
+    public function adjustPrice(Adjustment $adjustment): void
     {
-        $this->currentprice -= $a->getValue();
-        $this->setBestAdjustment($a);
-        $this->adjustments[] = $a;
+        $this->currentprice -= $adjustment->getValue();
+        $this->setBestAdjustment($adjustment);
+        $this->adjustments[] = $adjustment;
     }
 
     public function getCompoundedDiscount(): int|float
@@ -66,11 +66,11 @@ class PriceInfo
      * Sets the best adjustment, if the passed adjustment
      * is indeed better.
      *
-     * @param Adjustment $candidate for better adjustment
+     * @param Adjustment $adjustment for better adjustment
      */
-    protected function setBestAdjustment(Adjustment $candidate): void
+    protected function setBestAdjustment(Adjustment $adjustment): void
     {
         $this->bestadjustment = $this->bestadjustment instanceof Adjustment ?
-            Adjustment::better_of($this->bestadjustment, $candidate) : $candidate;
+            Adjustment::better_of($this->bestadjustment, $adjustment) : $adjustment;
     }
 }

--- a/src/PriceInfo.php
+++ b/src/PriceInfo.php
@@ -7,55 +7,55 @@ namespace SilverShop\Discounts;
  */
 class PriceInfo
 {
-    protected $originalprice;
+    protected int|float $originalprice;
 
-    protected $currentprice; //for compounding discounts
+    protected int|float $currentprice; //for compounding discounts
 
-    protected $adjustments = [];
+    protected array $adjustments = [];
 
-    protected $bestadjustment;
+    protected ?Adjustment $bestadjustment;
 
-    public function __construct($price)
+    public function __construct(int|float $price)
     {
         $this->currentprice = $this->originalprice = $price;
     }
 
-    public function getOriginalPrice()
+    public function getOriginalPrice(): int|float
     {
         return $this->originalprice;
     }
 
-    public function getPrice()
+    public function getPrice(): int|float
     {
         return $this->currentprice;
     }
 
-    public function adjustPrice(Adjustment $a)
+    public function adjustPrice(Adjustment $a): void
     {
         $this->currentprice -= $a->getValue();
         $this->setBestAdjustment($a);
         $this->adjustments[] = $a;
     }
 
-    public function getCompoundedDiscount()
+    public function getCompoundedDiscount(): int|float
     {
         return $this->originalprice - $this->currentprice;
     }
 
-    public function getBestDiscount()
+    public function getBestDiscount(): int|float
     {
-        if ($this->bestadjustment) {
+        if ($this->bestadjustment instanceof Adjustment) {
             return $this->bestadjustment->getValue();
         }
         return 0;
     }
 
-    public function getBestAdjustment()
+    public function getBestAdjustment(): ?Adjustment
     {
         return $this->bestadjustment;
     }
 
-    public function getAdjustments()
+    public function getAdjustments(): array
     {
         return $this->adjustments;
     }
@@ -66,7 +66,7 @@ class PriceInfo
      *
      * @param Adjustment $candidate for better adjustment
      */
-    protected function setBestAdjustment(Adjustment $candidate)
+    protected function setBestAdjustment(Adjustment $candidate): void
     {
         $this->bestadjustment = $this->bestadjustment ?
             Adjustment::better_of($this->bestadjustment, $candidate) : $candidate;

--- a/src/PriceInfo.php
+++ b/src/PriceInfo.php
@@ -68,7 +68,7 @@ class PriceInfo
      */
     protected function setBestAdjustment(Adjustment $candidate): void
     {
-        $this->bestadjustment = $this->bestadjustment ?
+        $this->bestadjustment = $this->bestadjustment instanceof Adjustment ?
             Adjustment::better_of($this->bestadjustment, $candidate) : $candidate;
     }
 }

--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -67,27 +67,27 @@ class CalculatorTest extends SapphireTest
     {
         $adjustment1 = new Adjustment(10, null);
         $adjustment2 = new Adjustment(5, null);
-        $this->assertEquals(10, $adjustment1->getValue());
+        $this->assertSame(10, $adjustment1->getValue());
         $this->assertEquals($adjustment1, Adjustment::better_of($adjustment1, $adjustment2));
     }
 
     public function testPriceInfo(): void
     {
         $priceInfo = new PriceInfo(20);
-        $this->assertEquals(20, $priceInfo->getPrice());
-        $this->assertEquals(20, $priceInfo->getOriginalPrice());
-        $this->assertEquals(0, $priceInfo->getCompoundedDiscount());
-        $this->assertEquals(0, $priceInfo->getBestDiscount());
-        $this->assertEquals([], $priceInfo->getAdjustments());
+        $this->assertSame(20, $priceInfo->getPrice());
+        $this->assertSame(20, $priceInfo->getOriginalPrice());
+        $this->assertSame(0, $priceInfo->getCompoundedDiscount());
+        $this->assertSame(0, $priceInfo->getBestDiscount());
+        $this->assertSame([], $priceInfo->getAdjustments());
 
         $priceInfo->adjustPrice($a1 = new Adjustment(1, 'a'));
         $priceInfo->adjustPrice($a2 = new Adjustment(5, 'b'));
         $priceInfo->adjustPrice($a3 = new Adjustment(2, 'c'));
 
-        $this->assertEquals(12, $priceInfo->getPrice());
-        $this->assertEquals(20, $priceInfo->getOriginalPrice());
-        $this->assertEquals(8, $priceInfo->getCompoundedDiscount());
-        $this->assertEquals(5, $priceInfo->getBestDiscount());
+        $this->assertSame(12, $priceInfo->getPrice());
+        $this->assertSame(20, $priceInfo->getOriginalPrice());
+        $this->assertSame(8, $priceInfo->getCompoundedDiscount());
+        $this->assertSame(5, $priceInfo->getBestDiscount());
         $this->assertEquals([$a1,$a2,$a3], $priceInfo->getAdjustments());
     }
 
@@ -103,7 +103,7 @@ class CalculatorTest extends SapphireTest
         );
         $orderDiscount->write();
         //check that discount works as expected
-        $this->assertEquals(1, $orderDiscount->getDiscountValue(10), '10% of 10 is 1');
+        $this->assertSame(1, (int) $orderDiscount->getDiscountValue(10), '10% of 10 is 1');
         //check that discount matches order
         $arrayList = Discount::get_matching($this->cart);
         $this->assertListEquals(
@@ -117,9 +117,12 @@ class CalculatorTest extends SapphireTest
         $this->assertTrue($valid, 'discount is valid');
         //check calculator
         $calculator = new Calculator($this->cart);
-        $this->assertEquals(0.8, $calculator->calculate(), '10% of $8');
+        $this->assertEqualsWithDelta(0.8, $calculator->calculate(), PHP_FLOAT_EPSILON);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testZeroOrderDiscount(): void
     {
         OrderDiscount::create(
@@ -165,20 +168,20 @@ class CalculatorTest extends SapphireTest
         );
 
         $calculator = new Calculator($this->emptycart);
-        $this->assertEquals(0, $calculator->calculate(), 'nothing in cart');
+        $this->assertSame(0, (int) $calculator->calculate(), 'nothing in cart');
         //check that best discount was chosen
         $calculator = new Calculator($this->cart);
-        $this->assertEquals(5, $calculator->calculate(), '$5 off $8 is best discount');
+        $this->assertSame(5, (int) $calculator->calculate(), '$5 off $8 is best discount');
 
         $calculator = new Calculator($this->othercart);
-        $this->assertEquals(20, $calculator->calculate(), '10% off $400 is best discount');
+        $this->assertSame(20, (int) $calculator->calculate(), '10% off $400 is best discount');
         //total discount calculation
         //20 * socks($8) = 160 ...$5 off each = 100
         //10 * tshirt($25) = 250 ..$5 off each  = 50
         //2 * mp3player($200) = 400 ..10% off each = 40
         //total discount: 190
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(190, $calculator->calculate(), 'complex savings example');
+        $this->assertSame(190, (int) $calculator->calculate(), 'complex savings example');
 
         $this->assertListEquals(
             [
@@ -200,10 +203,10 @@ class CalculatorTest extends SapphireTest
         )->write();
         OrderCoupon::create(
             [
-            'Title' => '$10 off each item',
-            'Code' => 'TENDOLLARSOFF',
-            'Type' => 'Amount',
-            'Amount' => 10
+                'Title' => '$10 off each item',
+                'Code' => 'TENDOLLARSOFF',
+                'Type' => 'Amount',
+                'Amount' => 10
             ]
         )->write();
 
@@ -215,13 +218,13 @@ class CalculatorTest extends SapphireTest
         $calculator = new Calculator(
             $this->megacart,
             [
-            'CouponCode' => 'TENDOLLARSOFF'
+                'CouponCode' => 'TENDOLLARSOFF'
             ]
         );
-        $this->assertEquals(300, $calculator->calculate(), 'complex savings example');
+        $this->assertSame(300, (int) $calculator->calculate(), 'complex savings example');
         //no coupon in context
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(81, $calculator->calculate(), 'complex savings example');
+        $this->assertSame(81, (int) $calculator->calculate(), 'complex savings example');
         //write a test that combines discounts which sum to a greater discount than
         //the order subtotal
     }
@@ -230,26 +233,26 @@ class CalculatorTest extends SapphireTest
     {
         OrderDiscount::create(
             [
-            'Title' => '$400 savings',
-            'Type' => 'Amount',
-            'Amount' => 400,
-            'ForItems' => false,
-            'ForCart' => true
+                'Title' => '$400 savings',
+                'Type' => 'Amount',
+                'Amount' => 400,
+                'ForItems' => false,
+                'ForCart' => true
             ]
         )->write();
 
         OrderDiscount::create(
             [
-            'Title' => '$500 off baby!',
-            'Type' => 'Amount',
-            'Amount' => 500,
-            'ForItems' => true,
-            'ForCart' => false
+                'Title' => '$500 off baby!',
+                'Type' => 'Amount',
+                'Amount' => 500,
+                'ForItems' => true,
+                'ForCart' => false
             ]
         )->write();
 
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(810, $calculator->calculate(), "total shouldn't exceed what is possible");
+        $this->assertSame(810, (int) $calculator->calculate(), "total shouldn't exceed what is possible");
 
         $this->markTestIncomplete('test distribution of amounts');
     }
@@ -259,32 +262,32 @@ class CalculatorTest extends SapphireTest
         //entire cart
         $orderDiscount = OrderDiscount::create(
             [
-            'Title' => '$25 off cart total',
-            'Type' => 'Amount',
-            'Amount' => 25,
-            'ForItems' => false,
-            'ForCart' => true
+                'Title' => '$25 off cart total',
+                'Type' => 'Amount',
+                'Amount' => 25,
+                'ForItems' => false,
+                'ForCart' => true
             ]
         );
         $orderDiscount->write();
         $this->assertTrue($orderDiscount->validateOrder($this->cart));
         $calculator = new Calculator($this->cart);
-        $this->assertEquals(8, $calculator->calculate());
+        $this->assertSame(8, (int) $calculator->calculate());
         $calculator = new Calculator($this->othercart);
-        $this->assertEquals(25, $calculator->calculate());
+        $this->assertSame(25, (int) $calculator->calculate());
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(25, $calculator->calculate());
+        $this->assertSame(25, (int) $calculator->calculate());
     }
 
     public function testCartLevelPercent(): void
     {
         $orderDiscount = OrderDiscount::create(
             [
-            'Title' => '50% off products subtotal',
-            'Type' => 'Percent',
-            'Percent' => 0.5,
-            'ForItems' => false,
-            'ForCart' => true
+                'Title' => '50% off products subtotal',
+                'Type' => 'Percent',
+                'Percent' => 0.5,
+                'ForItems' => false,
+                'ForCart' => true
             ]
         );
         $orderDiscount->write();
@@ -292,14 +295,14 @@ class CalculatorTest extends SapphireTest
         //products subtotal
         $orderDiscount->Products()->addMany(
             [
-            $this->socks,
-            $this->tshirt
+                $this->socks,
+                $this->tshirt
             ]
         );
         $calculator = new Calculator($this->cart);
-        $this->assertEquals(4, $calculator->calculate());
+        $this->assertSame(4, (int) $calculator->calculate());
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(205, $calculator->calculate());
+        $this->assertSame(205, (int) $calculator->calculate());
     }
 
     public function testMaxAmount(): void
@@ -307,17 +310,17 @@ class CalculatorTest extends SapphireTest
         //percent item discounts
         $discount = OrderDiscount::create(
             [
-            'Title' => '$200 max Discount',
-            'Type' => 'Percent',
-            'Percent' => 0.8,
-            'MaxAmount' => 200,
-            'ForItems' => true
+                'Title' => '$200 max Discount',
+                'Type' => 'Percent',
+                'Percent' => 0.8,
+                'MaxAmount' => 200,
+                'ForItems' => true
             ]
         );
         $discount->write();
 
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(200, $calculator->calculate());
+        $this->assertSame(200, (int) $calculator->calculate());
         //clean up
         $discount->Active = 0;
         $discount->write();
@@ -325,17 +328,17 @@ class CalculatorTest extends SapphireTest
         //amount item discounts
         $discount = OrderDiscount::create(
             [
-            'Title' => '$20 max Discount (using amount)',
-            'Type' => 'Amount',
-            'Amount' => 10,
-            'MaxAmount' => 20,
-            'ForItems' => true
+                'Title' => '$20 max Discount (using amount)',
+                'Type' => 'Amount',
+                'Amount' => 10,
+                'MaxAmount' => 20,
+                'ForItems' => true
             ]
         );
         $discount->write();
 
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(20, $calculator->calculate());
+        $this->assertSame(20, (int) $calculator->calculate());
         //clean up
         $discount->Active = 0;
         $discount->write();
@@ -343,52 +346,52 @@ class CalculatorTest extends SapphireTest
         //percent cart discounts
         OrderDiscount::create(
             [
-            'Title' => '40 max Discount (using amount)',
-            'Type' => 'Percent',
-            'Percent' => 0.8,
-            'MaxAmount' => 40,
-            'ForItems' => false,
-            'ForCart' => true
+                'Title' => '40 max Discount (using amount)',
+                'Type' => 'Percent',
+                'Percent' => 0.8,
+                'MaxAmount' => 40,
+                'ForItems' => false,
+                'ForCart' => true
             ]
         )->write();
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(40, $calculator->calculate());
+        $this->assertSame(40, (int) $calculator->calculate());
     }
 
     public function testSavingsTotal(): void
     {
         $discount = $this->objFromFixture(OrderDiscount::class, 'limited');
-        $this->assertEquals(44, $discount->getSavingsTotal());
+        $this->assertSame(44, (int) $discount->getSavingsTotal());
         $discount = $this->objFromFixture(OrderCoupon::class, 'limited');
-        $this->assertEquals(22, $discount->getSavingsTotal());
+        $this->assertSame(22, (int) $discount->getSavingsTotal());
     }
 
     public function testOrderSavingsTotal(): void
     {
         $discount = $this->objFromFixture(OrderDiscount::class, 'limited');
         $order = $this->objFromFixture(Order::class, 'limitedcoupon');
-        $this->assertEquals(44, $discount->getSavingsforOrder($order));
+        $this->assertSame(44, (int) $discount->getSavingsforOrder($order));
 
         $discount = $this->objFromFixture(OrderCoupon::class, 'limited');
         $order = $this->objFromFixture(Order::class, 'limitedcoupon');
-        $this->assertEquals(22, $discount->getSavingsforOrder($order));
+        $this->assertSame(22, (int) $discount->getSavingsforOrder($order));
     }
 
     public function testProcessDiscountedOrder(): void
     {
         OrderDiscount::create(
             [
-            'Title' => '$25 off cart total',
-            'Type' => 'Amount',
-            'Amount' => 25,
-            'ForItems' => false,
-            'ForCart' => true
+                'Title' => '$25 off cart total',
+                'Type' => 'Amount',
+                'Amount' => 25,
+                'ForItems' => false,
+                'ForCart' => true
             ]
         )->write();
         $order = $this->objFromFixture(Order::class, 'payablecart');
-        $this->assertEquals(16, $order->calculate());
+        $this->assertSame(16, (int) $order->calculate());
         $orderProcessor = new OrderProcessor($order);
         $orderProcessor->placeOrder();
-        $this->assertEquals(16, Order::get()->byID($order->ID)->GrandTotal());
+        $this->assertSame(16, (int) Order::get()->byID($order->ID)->GrandTotal());
     }
 }

--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -23,15 +23,22 @@ class CalculatorTest extends SapphireTest
     ];
 
     protected Order $cart;
+
     protected Order $emptycart;
+
     protected Order $megacart;
+
     protected Order $modifiedcart;
+
     protected Order $othercart;
+
     protected Product $socks;
+
     protected Product $tshirt;
+
     protected Product $mp3player;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();
@@ -42,8 +49,10 @@ class CalculatorTest extends SapphireTest
 
         $this->socks = $this->objFromFixture(Product::class, 'socks');
         $this->socks->publishRecursive();
+
         $this->tshirt = $this->objFromFixture(Product::class, 'tshirt');
         $this->tshirt->publishRecursive();
+
         $this->mp3player = $this->objFromFixture(Product::class, 'mp3player');
         $this->mp3player->publishRecursive();
 
@@ -306,6 +315,7 @@ class CalculatorTest extends SapphireTest
             ]
         );
         $discount->write();
+
         $calculator = new Calculator($this->megacart);
         $this->assertEquals(200, $calculator->calculate());
         //clean up
@@ -323,6 +333,7 @@ class CalculatorTest extends SapphireTest
             ]
         );
         $discount->write();
+
         $calculator = new Calculator($this->megacart);
         $this->assertEquals(20, $calculator->calculate());
         //clean up

--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -116,7 +116,7 @@ class CalculatorTest extends SapphireTest
         $valid = $orderDiscount->validateOrder($this->cart);
         $this->assertTrue($valid, 'discount is valid');
         //check calculator
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertEqualsWithDelta(0.8, $calculator->calculate(), PHP_FLOAT_EPSILON);
     }
 
@@ -167,20 +167,20 @@ class CalculatorTest extends SapphireTest
             $arrayList
         );
 
-        $calculator = new Calculator($this->emptycart);
+        $calculator = Calculator::create($this->emptycart);
         $this->assertSame(0, (int) $calculator->calculate(), 'nothing in cart');
         //check that best discount was chosen
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertSame(5, (int) $calculator->calculate(), '$5 off $8 is best discount');
 
-        $calculator = new Calculator($this->othercart);
+        $calculator = Calculator::create($this->othercart);
         $this->assertSame(20, (int) $calculator->calculate(), '10% off $400 is best discount');
         //total discount calculation
         //20 * socks($8) = 160 ...$5 off each = 100
         //10 * tshirt($25) = 250 ..$5 off each  = 50
         //2 * mp3player($200) = 400 ..10% off each = 40
         //total discount: 190
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(190, (int) $calculator->calculate(), 'complex savings example');
 
         $this->assertListEquals(
@@ -215,7 +215,7 @@ class CalculatorTest extends SapphireTest
         //10 * tshirt($25) = 250 ..$10 off each  = 100
         //2 * mp3player($200) = 400 ..10% off each = 40
         //total discount: 300
-        $calculator = new Calculator(
+        $calculator = Calculator::create(
             $this->megacart,
             [
                 'CouponCode' => 'TENDOLLARSOFF'
@@ -223,7 +223,7 @@ class CalculatorTest extends SapphireTest
         );
         $this->assertSame(300, (int) $calculator->calculate(), 'complex savings example');
         //no coupon in context
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(81, (int) $calculator->calculate(), 'complex savings example');
         //write a test that combines discounts which sum to a greater discount than
         //the order subtotal
@@ -251,7 +251,7 @@ class CalculatorTest extends SapphireTest
             ]
         )->write();
 
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(810, (int) $calculator->calculate(), "total shouldn't exceed what is possible");
 
         $this->markTestIncomplete('test distribution of amounts');
@@ -271,11 +271,11 @@ class CalculatorTest extends SapphireTest
         );
         $orderDiscount->write();
         $this->assertTrue($orderDiscount->validateOrder($this->cart));
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertSame(8, (int) $calculator->calculate());
-        $calculator = new Calculator($this->othercart);
+        $calculator = Calculator::create($this->othercart);
         $this->assertSame(25, (int) $calculator->calculate());
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(25, (int) $calculator->calculate());
     }
 
@@ -299,9 +299,9 @@ class CalculatorTest extends SapphireTest
                 $this->tshirt
             ]
         );
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertSame(4, (int) $calculator->calculate());
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(205, (int) $calculator->calculate());
     }
 
@@ -319,10 +319,10 @@ class CalculatorTest extends SapphireTest
         );
         $discount->write();
 
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(200, (int) $calculator->calculate());
         //clean up
-        $discount->Active = 0;
+        $discount->Active = false;
         $discount->write();
 
         //amount item discounts
@@ -337,10 +337,10 @@ class CalculatorTest extends SapphireTest
         );
         $discount->write();
 
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(20, (int) $calculator->calculate());
         //clean up
-        $discount->Active = 0;
+        $discount->Active = false;
         $discount->write();
 
         //percent cart discounts
@@ -354,7 +354,7 @@ class CalculatorTest extends SapphireTest
                 'ForCart' => true
             ]
         )->write();
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(40, (int) $calculator->calculate());
     }
 
@@ -390,7 +390,7 @@ class CalculatorTest extends SapphireTest
         )->write();
         $order = $this->objFromFixture(Order::class, 'payablecart');
         $this->assertSame(16, (int) $order->calculate());
-        $orderProcessor = new OrderProcessor($order);
+        $orderProcessor = OrderProcessor::create($order);
         $orderProcessor->placeOrder();
         $this->assertSame(16, (int) Order::get()->byID($order->ID)->GrandTotal());
     }

--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -22,6 +22,15 @@ class CalculatorTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+    protected Order $emptycart;
+    protected Order $megacart;
+    protected Order $modifiedcart;
+    protected Order $othercart;
+    protected Product $socks;
+    protected Product $tshirt;
+    protected Product $mp3player;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -45,7 +54,7 @@ class CalculatorTest extends SapphireTest
         $this->modifiedcart = $this->objFromFixture(Order::class, 'modifiedcart');
     }
 
-    public function testAdjustment()
+    public function testAdjustment(): void
     {
         $adjustment1 = new Adjustment(10, null);
         $adjustment2 = new Adjustment(5, null);
@@ -53,7 +62,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals($adjustment1, Adjustment::better_of($adjustment1, $adjustment2));
     }
 
-    public function testPriceInfo()
+    public function testPriceInfo(): void
     {
         $i = new PriceInfo(20);
         $this->assertEquals(20, $i->getPrice());
@@ -73,7 +82,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals([$a1,$a2,$a3], $i->getAdjustments());
     }
 
-    public function testBasicItemDiscount()
+    public function testBasicItemDiscount(): void
     {
         //activate discounts
         $discount = OrderDiscount::create(
@@ -90,7 +99,7 @@ class CalculatorTest extends SapphireTest
         $matching = Discount::get_matching($this->cart);
         $this->assertListEquals(
             [
-            ['Title' => '10% off']
+                ['Title' => '10% off']
             ],
             $matching
         );
@@ -102,37 +111,37 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals(0.8, $calculator->calculate(), '10% of $8');
     }
 
-    public function testZeroOrderDiscount()
+    public function testZeroOrderDiscount(): void
     {
         OrderDiscount::create(
             [
-            'Title' => 'Everything is free!',
-            'Type' => 'Percent',
-            'Percent' => 1,
-            'ForItems' => 1,
-            'ForCart' => 1,
-            'ForShipping' => 1
+                'Title' => 'Everything is free!',
+                'Type' => 'Percent',
+                'Percent' => 1,
+                'ForItems' => 1,
+                'ForCart' => 1,
+                'ForShipping' => 1
             ]
         )->write();
         $this->markTestIncomplete('Add assertions');
     }
 
-    public function testItemLevelPercentAndAmountDiscounts()
+    public function testItemLevelPercentAndAmountDiscounts(): void
     {
         OrderDiscount::get()->removeAll();
         OrderDiscount::create(
             [
-            'Title' => '10% off',
-            'Type' => 'Percent',
-            'Percent' => 0.10
+                'Title' => '10% off',
+                'Type' => 'Percent',
+                'Percent' => 0.10
             ]
         )->write();
 
         OrderDiscount::create(
             [
-            'Title' => '$5 off',
-            'Type' => 'Amount',
-            'Amount' => 5
+                'Title' => '$5 off',
+                'Type' => 'Amount',
+                'Amount' => 5
             ]
         )->write();
 
@@ -140,8 +149,8 @@ class CalculatorTest extends SapphireTest
         $matching = Discount::get_matching($this->cart);
         $this->assertListEquals(
             [
-            ['Title' => '10% off'],
-            ['Title' => '$5 off']
+                ['Title' => '10% off'],
+                ['Title' => '$5 off']
             ],
             $matching
         );
@@ -164,14 +173,14 @@ class CalculatorTest extends SapphireTest
 
         $this->assertListEquals(
             [
-            ['Title' => '10% off'],
-            ['Title' => '$5 off']
+                ['Title' => '10% off'],
+                ['Title' => '$5 off']
             ],
             $this->megacart->Discounts()
         );
     }
 
-    public function testCouponAndDiscountItemLevel()
+    public function testCouponAndDiscountItemLevel(): void
     {
         OrderDiscount::create(
             [
@@ -208,7 +217,7 @@ class CalculatorTest extends SapphireTest
         //the order subtotal
     }
 
-    public function testItemAndCartLevelAmountDiscounts()
+    public function testItemAndCartLevelAmountDiscounts(): void
     {
         OrderDiscount::create(
             [
@@ -236,7 +245,7 @@ class CalculatorTest extends SapphireTest
         $this->markTestIncomplete('test distribution of amounts');
     }
 
-    public function testCartLevelAmount()
+    public function testCartLevelAmount(): void
     {
         //entire cart
         $discount = OrderDiscount::create(
@@ -258,7 +267,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals(25, $calculator->calculate());
     }
 
-    public function testCartLevelPercent()
+    public function testCartLevelPercent(): void
     {
         $discount = OrderDiscount::create(
             [
@@ -284,7 +293,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals(205, $calculator->calculate());
     }
 
-    public function testMaxAmount()
+    public function testMaxAmount(): void
     {
         //percent item discounts
         $discount = OrderDiscount::create(
@@ -335,7 +344,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals(40, $calculator->calculate());
     }
 
-    public function testSavingsTotal()
+    public function testSavingsTotal(): void
     {
         $discount = $this->objFromFixture(OrderDiscount::class, 'limited');
         $this->assertEquals(44, $discount->getSavingsTotal());
@@ -343,7 +352,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals(22, $discount->getSavingsTotal());
     }
 
-    public function testOrderSavingsTotal()
+    public function testOrderSavingsTotal(): void
     {
         $discount = $this->objFromFixture(OrderDiscount::class, 'limited');
         $order = $this->objFromFixture(Order::class, 'limitedcoupon');
@@ -354,7 +363,7 @@ class CalculatorTest extends SapphireTest
         $this->assertEquals(22, $discount->getSavingsforOrder($order));
     }
 
-    public function testProcessDiscountedOrder()
+    public function testProcessDiscountedOrder(): void
     {
         OrderDiscount::create(
             [

--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -73,47 +73,47 @@ class CalculatorTest extends SapphireTest
 
     public function testPriceInfo(): void
     {
-        $i = new PriceInfo(20);
-        $this->assertEquals(20, $i->getPrice());
-        $this->assertEquals(20, $i->getOriginalPrice());
-        $this->assertEquals(0, $i->getCompoundedDiscount());
-        $this->assertEquals(0, $i->getBestDiscount());
-        $this->assertEquals([], $i->getAdjustments());
+        $priceInfo = new PriceInfo(20);
+        $this->assertEquals(20, $priceInfo->getPrice());
+        $this->assertEquals(20, $priceInfo->getOriginalPrice());
+        $this->assertEquals(0, $priceInfo->getCompoundedDiscount());
+        $this->assertEquals(0, $priceInfo->getBestDiscount());
+        $this->assertEquals([], $priceInfo->getAdjustments());
 
-        $i->adjustPrice($a1 = new Adjustment(1, 'a'));
-        $i->adjustPrice($a2 = new Adjustment(5, 'b'));
-        $i->adjustPrice($a3 = new Adjustment(2, 'c'));
+        $priceInfo->adjustPrice($a1 = new Adjustment(1, 'a'));
+        $priceInfo->adjustPrice($a2 = new Adjustment(5, 'b'));
+        $priceInfo->adjustPrice($a3 = new Adjustment(2, 'c'));
 
-        $this->assertEquals(12, $i->getPrice());
-        $this->assertEquals(20, $i->getOriginalPrice());
-        $this->assertEquals(8, $i->getCompoundedDiscount());
-        $this->assertEquals(5, $i->getBestDiscount());
-        $this->assertEquals([$a1,$a2,$a3], $i->getAdjustments());
+        $this->assertEquals(12, $priceInfo->getPrice());
+        $this->assertEquals(20, $priceInfo->getOriginalPrice());
+        $this->assertEquals(8, $priceInfo->getCompoundedDiscount());
+        $this->assertEquals(5, $priceInfo->getBestDiscount());
+        $this->assertEquals([$a1,$a2,$a3], $priceInfo->getAdjustments());
     }
 
     public function testBasicItemDiscount(): void
     {
         //activate discounts
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => '10% off',
             'Type' => 'Percent',
             'Percent' => 0.1
             ]
         );
-        $discount->write();
+        $orderDiscount->write();
         //check that discount works as expected
-        $this->assertEquals(1, $discount->getDiscountValue(10), '10% of 10 is 1');
+        $this->assertEquals(1, $orderDiscount->getDiscountValue(10), '10% of 10 is 1');
         //check that discount matches order
-        $matching = Discount::get_matching($this->cart);
+        $arrayList = Discount::get_matching($this->cart);
         $this->assertListEquals(
             [
                 ['Title' => '10% off']
             ],
-            $matching
+            $arrayList
         );
         //check valid
-        $valid = $discount->validateOrder($this->cart);
+        $valid = $orderDiscount->validateOrder($this->cart);
         $this->assertTrue($valid, 'discount is valid');
         //check calculator
         $calculator = new Calculator($this->cart);
@@ -155,13 +155,13 @@ class CalculatorTest extends SapphireTest
         )->write();
 
         //check that discount matches order
-        $matching = Discount::get_matching($this->cart);
+        $arrayList = Discount::get_matching($this->cart);
         $this->assertListEquals(
             [
                 ['Title' => '10% off'],
                 ['Title' => '$5 off']
             ],
-            $matching
+            $arrayList
         );
 
         $calculator = new Calculator($this->emptycart);
@@ -257,7 +257,7 @@ class CalculatorTest extends SapphireTest
     public function testCartLevelAmount(): void
     {
         //entire cart
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => '$25 off cart total',
             'Type' => 'Amount',
@@ -266,8 +266,8 @@ class CalculatorTest extends SapphireTest
             'ForCart' => true
             ]
         );
-        $discount->write();
-        $this->assertTrue($discount->validateOrder($this->cart));
+        $orderDiscount->write();
+        $this->assertTrue($orderDiscount->validateOrder($this->cart));
         $calculator = new Calculator($this->cart);
         $this->assertEquals(8, $calculator->calculate());
         $calculator = new Calculator($this->othercart);
@@ -278,7 +278,7 @@ class CalculatorTest extends SapphireTest
 
     public function testCartLevelPercent(): void
     {
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => '50% off products subtotal',
             'Type' => 'Percent',
@@ -287,10 +287,10 @@ class CalculatorTest extends SapphireTest
             'ForCart' => true
             ]
         );
-        $discount->write();
+        $orderDiscount->write();
 
         //products subtotal
-        $discount->Products()->addMany(
+        $orderDiscount->Products()->addMany(
             [
             $this->socks,
             $this->tshirt
@@ -385,10 +385,10 @@ class CalculatorTest extends SapphireTest
             'ForCart' => true
             ]
         )->write();
-        $cart = $this->objFromFixture(Order::class, 'payablecart');
-        $this->assertEquals(16, $cart->calculate());
-        $processor = new OrderProcessor($cart);
-        $processor->placeOrder();
-        $this->assertEquals(16, Order::get()->byID($cart->ID)->GrandTotal());
+        $order = $this->objFromFixture(Order::class, 'payablecart');
+        $this->assertEquals(16, $order->calculate());
+        $orderProcessor = new OrderProcessor($order);
+        $orderProcessor->placeOrder();
+        $this->assertEquals(16, Order::get()->byID($order->ID)->GrandTotal());
     }
 }

--- a/tests/CategoriesDiscountConstraintTest.php
+++ b/tests/CategoriesDiscountConstraintTest.php
@@ -73,11 +73,11 @@ class CategoriesDiscountConstraintTest extends SapphireTest
             'Order contains a t-shirt. ' . $orderDiscount->getMessage()
         );
         $calculator = new Calculator($this->cart);
-        $this->assertEquals($calculator->calculate(), 0.4, '5% discount for socks in cart');
+        $this->assertEqualsWithDelta(0.4, $calculator->calculate(), PHP_FLOAT_EPSILON);
 
         $this->assertFalse($orderDiscount->validateOrder($this->othercart), 'Order does not contain clothing');
         $calculator = new Calculator($this->othercart);
-        $this->assertEquals($calculator->calculate(), 0, 'No discount, because no product in category');
+        $this->assertSame(0, $calculator->calculate(), 'No discount, because no product in category');
 
         $orderDiscount->Categories()->removeAll();
 
@@ -90,6 +90,6 @@ class CategoriesDiscountConstraintTest extends SapphireTest
             "Order contains a kite. " . $orderDiscount->getMessage()
         );
         $calculator = new Calculator($this->kitecart);
-        $this->assertEquals($calculator->calculate(), 1.75, '5% discount for kite in cart');
+        $this->assertEqualsWithDelta(1.75, $calculator->calculate(), PHP_FLOAT_EPSILON);
     }
 }

--- a/tests/CategoriesDiscountConstraintTest.php
+++ b/tests/CategoriesDiscountConstraintTest.php
@@ -72,11 +72,11 @@ class CategoriesDiscountConstraintTest extends SapphireTest
             $orderDiscount->validateOrder($this->cart),
             'Order contains a t-shirt. ' . $orderDiscount->getMessage()
         );
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertEqualsWithDelta(0.4, $calculator->calculate(), PHP_FLOAT_EPSILON);
 
         $this->assertFalse($orderDiscount->validateOrder($this->othercart), 'Order does not contain clothing');
-        $calculator = new Calculator($this->othercart);
+        $calculator = Calculator::create($this->othercart);
         $this->assertSame(0, $calculator->calculate(), 'No discount, because no product in category');
 
         $orderDiscount->Categories()->removeAll();
@@ -89,7 +89,7 @@ class CategoriesDiscountConstraintTest extends SapphireTest
             $orderDiscount->validateOrder($this->kitecart),
             "Order contains a kite. " . $orderDiscount->getMessage()
         );
-        $calculator = new Calculator($this->kitecart);
+        $calculator = Calculator::create($this->kitecart);
         $this->assertEqualsWithDelta(1.75, $calculator->calculate(), PHP_FLOAT_EPSILON);
     }
 }

--- a/tests/CategoriesDiscountConstraintTest.php
+++ b/tests/CategoriesDiscountConstraintTest.php
@@ -12,30 +12,40 @@ use SilverStripe\Dev\SapphireTest;
 
 class CategoriesDiscountConstraintTest extends SapphireTest
 {
-
     protected static $fixture_file = [
         'shop.yml',
         'vendor/silvershop/core/tests/php/Fixtures/Carts.yml'
     ];
 
     protected Order $cart;
+
     protected Order $emptycart;
+
+    protected Order $kitecart;
+
     protected Order $megacart;
+
     protected Order $modifiedcart;
+
     protected Order $othercart;
+
     protected Product $socks;
+
     protected Product $tshirt;
+
     protected Product $mp3player;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();
 
         $this->socks = $this->objFromFixture(Product::class, "socks");
         $this->socks->publishRecursive();
+
         $this->tshirt = $this->objFromFixture(Product::class, "tshirt");
         $this->tshirt->publishRecursive();
+
         $this->mp3player = $this->objFromFixture(Product::class, "mp3player");
         $this->mp3player->publishRecursive();
 

--- a/tests/CategoriesDiscountConstraintTest.php
+++ b/tests/CategoriesDiscountConstraintTest.php
@@ -56,38 +56,38 @@ class CategoriesDiscountConstraintTest extends SapphireTest
 
     public function testCategoryDiscount(): void
     {
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
                 'Title' => '5% off clothing',
                 'Type' => 'Percent',
                 'Percent' => 0.05
             ]
         );
-        $discount->write();
-        $discount->Categories()->add(
+        $orderDiscount->write();
+        $orderDiscount->Categories()->add(
             $this->objFromFixture(ProductCategory::class, "clothing")
         );
 
         $this->assertTrue(
-            $discount->validateOrder($this->cart),
-            'Order contains a t-shirt. ' . $discount->getMessage()
+            $orderDiscount->validateOrder($this->cart),
+            'Order contains a t-shirt. ' . $orderDiscount->getMessage()
         );
         $calculator = new Calculator($this->cart);
         $this->assertEquals($calculator->calculate(), 0.4, '5% discount for socks in cart');
 
-        $this->assertFalse($discount->validateOrder($this->othercart), 'Order does not contain clothing');
+        $this->assertFalse($orderDiscount->validateOrder($this->othercart), 'Order does not contain clothing');
         $calculator = new Calculator($this->othercart);
         $this->assertEquals($calculator->calculate(), 0, 'No discount, because no product in category');
 
-        $discount->Categories()->removeAll();
+        $orderDiscount->Categories()->removeAll();
 
-        $discount->Categories()->add(
+        $orderDiscount->Categories()->add(
             $this->objFromFixture(ProductCategory::class, "kites")
         );
 
         $this->assertTrue(
-            $discount->validateOrder($this->kitecart),
-            "Order contains a kite. " . $discount->getMessage()
+            $orderDiscount->validateOrder($this->kitecart),
+            "Order contains a kite. " . $orderDiscount->getMessage()
         );
         $calculator = new Calculator($this->kitecart);
         $this->assertEquals($calculator->calculate(), 1.75, '5% discount for kite in cart');

--- a/tests/CategoriesDiscountConstraintTest.php
+++ b/tests/CategoriesDiscountConstraintTest.php
@@ -18,6 +18,15 @@ class CategoriesDiscountConstraintTest extends SapphireTest
         'vendor/silvershop/core/tests/php/Fixtures/Carts.yml'
     ];
 
+    protected Order $cart;
+    protected Order $emptycart;
+    protected Order $megacart;
+    protected Order $modifiedcart;
+    protected Order $othercart;
+    protected Product $socks;
+    protected Product $tshirt;
+    protected Product $mp3player;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -35,7 +44,7 @@ class CategoriesDiscountConstraintTest extends SapphireTest
         $this->kitecart = $this->objFromFixture(Order::class, 'kitecart');
     }
 
-    public function testCategoryDiscount()
+    public function testCategoryDiscount(): void
     {
         $discount = OrderDiscount::create(
             [
@@ -49,8 +58,10 @@ class CategoriesDiscountConstraintTest extends SapphireTest
             $this->objFromFixture(ProductCategory::class, "clothing")
         );
 
-        $this->assertTrue($discount->validateOrder($this->cart),
-            'Order contains a t-shirt. ' . $discount->getMessage());
+        $this->assertTrue(
+            $discount->validateOrder($this->cart),
+            'Order contains a t-shirt. ' . $discount->getMessage()
+        );
         $calculator = new Calculator($this->cart);
         $this->assertEquals($calculator->calculate(), 0.4, '5% discount for socks in cart');
 
@@ -64,8 +75,10 @@ class CategoriesDiscountConstraintTest extends SapphireTest
             $this->objFromFixture(ProductCategory::class, "kites")
         );
 
-        $this->assertTrue($discount->validateOrder($this->kitecart),
-            "Order contains a kite. " . $discount->getMessage());
+        $this->assertTrue(
+            $discount->validateOrder($this->kitecart),
+            "Order contains a kite. " . $discount->getMessage()
+        );
         $calculator = new Calculator($this->kitecart);
         $this->assertEquals($calculator->calculate(), 1.75, '5% discount for kite in cart');
     }

--- a/tests/CouponFormTest.php
+++ b/tests/CouponFormTest.php
@@ -26,7 +26,7 @@ class CouponFormTest extends FunctionalTest
         $this->objFromFixture(Product::class, 'socks')->publishRecursive();
     }
 
-    public function testCouponForm()
+    public function testCouponForm(): void
     {
         OrderCoupon::create(
             [

--- a/tests/DatetimeDiscountConstraintTest.php
+++ b/tests/DatetimeDiscountConstraintTest.php
@@ -13,6 +13,8 @@ class DatetimeDiscountConstraintTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -22,7 +24,7 @@ class DatetimeDiscountConstraintTest extends SapphireTest
         $this->cart = $this->objFromFixture(Order::class, 'cart');
     }
 
-    public function testDates()
+    public function testDates(): void
     {
         $unreleasedcoupon = OrderCoupon::create(
             [
@@ -36,8 +38,10 @@ class DatetimeDiscountConstraintTest extends SapphireTest
 
         $unreleasedcoupon->write();
         $context = ['CouponCode' => $unreleasedcoupon->Code];
-        $this->assertFalse($unreleasedcoupon->validateOrder($this->cart, $context),
-            'Coupon is un released (start date has not arrived)');
+        $this->assertFalse(
+            $unreleasedcoupon->validateOrder($this->cart, $context),
+            'Coupon is un released (start date has not arrived)'
+        );
 
         $expiredcoupon = OrderCoupon::create(
             [
@@ -53,7 +57,9 @@ class DatetimeDiscountConstraintTest extends SapphireTest
 
         $expiredcoupon->write();
         $context = ['CouponCode' => $expiredcoupon->Code];
-        $this->assertFalse($expiredcoupon->validateOrder($this->cart, $context),
-            'Coupon has expired (end date has passed)');
+        $this->assertFalse(
+            $expiredcoupon->validateOrder($this->cart, $context),
+            'Coupon has expired (end date has passed)'
+        );
     }
 }

--- a/tests/DatetimeDiscountConstraintTest.php
+++ b/tests/DatetimeDiscountConstraintTest.php
@@ -28,11 +28,11 @@ class DatetimeDiscountConstraintTest extends SapphireTest
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => 'Unreleased $10 off',
-            'Code' => '0444444440',
-            'Type' => 'Amount',
-            'Amount' => 10,
-            'StartDate' => '2200-01-01 12:00:00'
+                'Title' => 'Unreleased $10 off',
+                'Code' => '0444444440',
+                'Type' => 'Amount',
+                'Amount' => 10,
+                'StartDate' => '2200-01-01 12:00:00'
             ]
         );
 
@@ -46,13 +46,13 @@ class DatetimeDiscountConstraintTest extends SapphireTest
 
         $expiredcoupon = OrderCoupon::create(
             [
-            'Title' => 'Save lots',
-            'Code' => '04994C332A',
-            'Type' => 'Percent',
-            'Percent' => 0.8,
-            'Active' => 1,
-            'StartDate' => '',
-            'EndDate' => '12/12/1990'
+                'Title' => 'Save lots',
+                'Code' => '04994C332A',
+                'Type' => 'Percent',
+                'Percent' => 0.8,
+                'Active' => 1,
+                'StartDate' => '',
+                'EndDate' => '12/12/1990'
             ]
         );
 

--- a/tests/DatetimeDiscountConstraintTest.php
+++ b/tests/DatetimeDiscountConstraintTest.php
@@ -26,7 +26,7 @@ class DatetimeDiscountConstraintTest extends SapphireTest
 
     public function testDates(): void
     {
-        $unreleasedcoupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => 'Unreleased $10 off',
             'Code' => '0444444440',
@@ -36,11 +36,11 @@ class DatetimeDiscountConstraintTest extends SapphireTest
             ]
         );
 
-        $unreleasedcoupon->write();
+        $orderCoupon->write();
 
-        $context = ['CouponCode' => $unreleasedcoupon->Code];
+        $context = ['CouponCode' => $orderCoupon->Code];
         $this->assertFalse(
-            $unreleasedcoupon->validateOrder($this->cart, $context),
+            $orderCoupon->validateOrder($this->cart, $context),
             'Coupon is un released (start date has not arrived)'
         );
 

--- a/tests/DatetimeDiscountConstraintTest.php
+++ b/tests/DatetimeDiscountConstraintTest.php
@@ -15,7 +15,7 @@ class DatetimeDiscountConstraintTest extends SapphireTest
 
     protected Order $cart;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,6 +37,7 @@ class DatetimeDiscountConstraintTest extends SapphireTest
         );
 
         $unreleasedcoupon->write();
+
         $context = ['CouponCode' => $unreleasedcoupon->Code];
         $this->assertFalse(
             $unreleasedcoupon->validateOrder($this->cart, $context),
@@ -56,6 +57,7 @@ class DatetimeDiscountConstraintTest extends SapphireTest
         );
 
         $expiredcoupon->write();
+
         $context = ['CouponCode' => $expiredcoupon->Code];
         $this->assertFalse(
             $expiredcoupon->validateOrder($this->cart, $context),

--- a/tests/DiscountReportTest.php
+++ b/tests/DiscountReportTest.php
@@ -15,9 +15,9 @@ class DiscountReportTest extends SapphireTest
     public function testDiscountReport(): void
     {
         $this->objFromFixture(OrderDiscount::class, 'used');
-        $report = DiscountReport::create();
-        $records = $report->sourceRecords([]);
-        $this->assertEquals(44, $records->find('Title', 'Limited Discount')->getSavingsTotal());
-        $this->assertEquals(22, $records->find('Title', 'Limited Coupon')->getSavingsTotal());
+        $discountReport = DiscountReport::create();
+        $sqlQueryList = $discountReport->sourceRecords([]);
+        $this->assertEquals(44, $sqlQueryList->find('Title', 'Limited Discount')->getSavingsTotal());
+        $this->assertEquals(22, $sqlQueryList->find('Title', 'Limited Coupon')->getSavingsTotal());
     }
 }

--- a/tests/DiscountReportTest.php
+++ b/tests/DiscountReportTest.php
@@ -17,7 +17,7 @@ class DiscountReportTest extends SapphireTest
         $this->objFromFixture(OrderDiscount::class, 'used');
         $discountReport = DiscountReport::create();
         $sqlQueryList = $discountReport->sourceRecords([]);
-        $this->assertEquals(44, $sqlQueryList->find('Title', 'Limited Discount')->getSavingsTotal());
-        $this->assertEquals(22, $sqlQueryList->find('Title', 'Limited Coupon')->getSavingsTotal());
+        $this->assertEqualsWithDelta(44, (int) $sqlQueryList->find('Title', 'Limited Discount')->getSavingsTotal(), PHP_FLOAT_EPSILON);
+        $this->assertSame(22, (int) $sqlQueryList->find('Title', 'Limited Coupon')->getSavingsTotal());
     }
 }

--- a/tests/DiscountReportTest.php
+++ b/tests/DiscountReportTest.php
@@ -14,7 +14,7 @@ class DiscountReportTest extends SapphireTest
 
     public function testDiscountReport(): void
     {
-        $discount = $this->objFromFixture(OrderDiscount::class, 'used');
+        $this->objFromFixture(OrderDiscount::class, 'used');
         $report = DiscountReport::create();
         $records = $report->sourceRecords([]);
         $this->assertEquals(44, $records->find('Title', 'Limited Discount')->getSavingsTotal());

--- a/tests/DiscountReportTest.php
+++ b/tests/DiscountReportTest.php
@@ -12,7 +12,7 @@ class DiscountReportTest extends SapphireTest
 
     protected static $fixture_file = 'Discounts.yml';
 
-    public function testDiscountReport()
+    public function testDiscountReport(): void
     {
         $discount = $this->objFromFixture(OrderDiscount::class, 'used');
         $report = new DiscountReport();

--- a/tests/DiscountReportTest.php
+++ b/tests/DiscountReportTest.php
@@ -15,7 +15,7 @@ class DiscountReportTest extends SapphireTest
     public function testDiscountReport(): void
     {
         $discount = $this->objFromFixture(OrderDiscount::class, 'used');
-        $report = new DiscountReport();
+        $report = DiscountReport::create();
         $records = $report->sourceRecords([]);
         $this->assertEquals(44, $records->find('Title', 'Limited Discount')->getSavingsTotal());
         $this->assertEquals(22, $records->find('Title', 'Limited Coupon')->getSavingsTotal());

--- a/tests/GiftVoucherTest.php
+++ b/tests/GiftVoucherTest.php
@@ -33,25 +33,25 @@ class GiftVoucherTest extends SapphireTest
         $form = $giftVoucherProductController->Form();
 
         $form->loadDataFrom(
-            $data = [
-            'UnitPrice' => 32.35,
-            'Quantity' => 1
+            [
+                'UnitPrice' => 32.35,
+                'Quantity' => 1
             ]
         );
         $this->assertTrue($form->validationResult()->isValid(), 'Voucher form is valid');
 
         $form->loadDataFrom(
             [
-            'UnitPrice' => 3,
-            'Quantity' => 5
+                'UnitPrice' => 3,
+                'Quantity' => 5
             ]
         );
         $this->assertFalse($form->validationResult()->isValid(), 'Tested unit price is below minimum amount');
 
         $form->loadDataFrom(
             [
-            'UnitPrice' => 0,
-            'Quantity' => 5
+                'UnitPrice' => 0,
+                'Quantity' => 5
             ]
         );
         $this->assertFalse($form->validationResult()->isValid(), 'Tested unit price is zero');
@@ -62,9 +62,7 @@ class GiftVoucherTest extends SapphireTest
         $giftVoucherProductController =  GiftVoucherProductController::create($this->fixed10);
         $form = $giftVoucherProductController->Form();
         $form->loadDataFrom(
-            [
-            'Quantity' => 2
-            ]
+            ['Quantity' => 2]
         );
 
         $this->assertTrue($form->validationResult()->isValid(), 'Valid voucher');
@@ -74,14 +72,12 @@ class GiftVoucherTest extends SapphireTest
     {
         $orderItem = $this->variable->createItem(
             1,
-            [
-            'UnitPrice' => 15.00
-            ]
+            ['UnitPrice' => 15.00]
         );
 
         $coupon = $orderItem->createCoupon();
 
-        $this->assertEquals($coupon->Amount, 15, 'Coupon value is $15, as per order item');
-        $this->assertEquals($coupon->Type, 'Amount', "Coupon type is 'Amount'");
+        $this->assertEqualsWithDelta(15.00, $coupon->Amount, PHP_FLOAT_EPSILON);
+        $this->assertSame('Amount', $coupon->Type, "Coupon type is 'Amount'");
     }
 }

--- a/tests/GiftVoucherTest.php
+++ b/tests/GiftVoucherTest.php
@@ -29,8 +29,8 @@ class GiftVoucherTest extends SapphireTest
 
     public function testCusomisableVoucher(): void
     {
-        $controller =  GiftVoucherProductController::create($this->variable);
-        $form = $controller->Form();
+        $giftVoucherProductController =  GiftVoucherProductController::create($this->variable);
+        $form = $giftVoucherProductController->Form();
 
         $form->loadDataFrom(
             $data = [
@@ -59,8 +59,8 @@ class GiftVoucherTest extends SapphireTest
 
     public function testFixedVoucher(): void
     {
-        $controller =  GiftVoucherProductController::create($this->fixed10);
-        $form = $controller->Form();
+        $giftVoucherProductController =  GiftVoucherProductController::create($this->fixed10);
+        $form = $giftVoucherProductController->Form();
         $form->loadDataFrom(
             [
             'Quantity' => 2
@@ -72,14 +72,14 @@ class GiftVoucherTest extends SapphireTest
 
     public function testCreateCoupon(): void
     {
-        $item = $this->variable->createItem(
+        $orderItem = $this->variable->createItem(
             1,
             [
             'UnitPrice' => 15.00
             ]
         );
 
-        $coupon = $item->createCoupon();
+        $coupon = $orderItem->createCoupon();
 
         $this->assertEquals($coupon->Amount, 15, 'Coupon value is $15, as per order item');
         $this->assertEquals($coupon->Type, 'Amount', "Coupon type is 'Amount'");

--- a/tests/GiftVoucherTest.php
+++ b/tests/GiftVoucherTest.php
@@ -12,6 +12,9 @@ class GiftVoucherTest extends SapphireTest
         'GiftVouchers.yml'
     ];
 
+    protected GiftVoucherProduct $fixed10;
+    protected GiftVoucherProduct $variable;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -23,7 +26,7 @@ class GiftVoucherTest extends SapphireTest
         $this->fixed10->copyVersionToStage('Stage', 'Live');
     }
 
-    public function testCusomisableVoucher()
+    public function testCusomisableVoucher(): void
     {
         $controller =  new GiftVoucherProductController($this->variable);
         $form = $controller->Form();
@@ -53,7 +56,7 @@ class GiftVoucherTest extends SapphireTest
         $this->assertFalse($form->validationResult()->isValid(), 'Tested unit price is zero');
     }
 
-    public function testFixedVoucher()
+    public function testFixedVoucher(): void
     {
         $controller =  new GiftVoucherProductController($this->fixed10);
         $form = $controller->Form();
@@ -66,7 +69,7 @@ class GiftVoucherTest extends SapphireTest
         $this->assertTrue($form->validationResult()->isValid(), 'Valid voucher');
     }
 
-    public function testCreateCoupon()
+    public function testCreateCoupon(): void
     {
         $item = $this->variable->createItem(
             1,

--- a/tests/GiftVoucherTest.php
+++ b/tests/GiftVoucherTest.php
@@ -13,9 +13,10 @@ class GiftVoucherTest extends SapphireTest
     ];
 
     protected GiftVoucherProduct $fixed10;
+
     protected GiftVoucherProduct $variable;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/GiftVoucherTest.php
+++ b/tests/GiftVoucherTest.php
@@ -12,24 +12,24 @@ class GiftVoucherTest extends SapphireTest
         'GiftVouchers.yml'
     ];
 
-    protected GiftVoucherProduct $fixed10;
+    protected GiftVoucherProduct $fixed10GiftVoucherProduct;
 
-    protected GiftVoucherProduct $variable;
+    protected GiftVoucherProduct $variableGiftVoucherProduct;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->variable = $this->objFromFixture(GiftVoucherProduct::class, 'variable');
-        $this->variable->copyVersionToStage('Stage', 'Live');
+        $this->variableGiftVoucherProduct = $this->objFromFixture(GiftVoucherProduct::class, 'variable');
+        $this->variableGiftVoucherProduct->copyVersionToStage('Stage', 'Live');
 
-        $this->fixed10 = $this->objFromFixture(GiftVoucherProduct::class, '10fixed');
-        $this->fixed10->copyVersionToStage('Stage', 'Live');
+        $this->fixed10GiftVoucherProduct = $this->objFromFixture(GiftVoucherProduct::class, '10fixed');
+        $this->fixed10GiftVoucherProduct->copyVersionToStage('Stage', 'Live');
     }
 
     public function testCusomisableVoucher(): void
     {
-        $giftVoucherProductController =  GiftVoucherProductController::create($this->variable);
+        $giftVoucherProductController =  GiftVoucherProductController::create($this->variableGiftVoucherProduct);
         $form = $giftVoucherProductController->Form();
 
         $form->loadDataFrom(
@@ -59,7 +59,7 @@ class GiftVoucherTest extends SapphireTest
 
     public function testFixedVoucher(): void
     {
-        $giftVoucherProductController =  GiftVoucherProductController::create($this->fixed10);
+        $giftVoucherProductController =  GiftVoucherProductController::create($this->fixed10GiftVoucherProduct);
         $form = $giftVoucherProductController->Form();
         $form->loadDataFrom(
             ['Quantity' => 2]
@@ -70,7 +70,7 @@ class GiftVoucherTest extends SapphireTest
 
     public function testCreateCoupon(): void
     {
-        $orderItem = $this->variable->createItem(
+        $orderItem = $this->variableGiftVoucherProduct->createItem(
             1,
             ['UnitPrice' => 15.00]
         );

--- a/tests/GiftVoucherTest.php
+++ b/tests/GiftVoucherTest.php
@@ -28,7 +28,7 @@ class GiftVoucherTest extends SapphireTest
 
     public function testCusomisableVoucher(): void
     {
-        $controller =  new GiftVoucherProductController($this->variable);
+        $controller =  GiftVoucherProductController::create($this->variable);
         $form = $controller->Form();
 
         $form->loadDataFrom(
@@ -58,7 +58,7 @@ class GiftVoucherTest extends SapphireTest
 
     public function testFixedVoucher(): void
     {
-        $controller =  new GiftVoucherProductController($this->fixed10);
+        $controller =  GiftVoucherProductController::create($this->fixed10);
         $form = $controller->Form();
         $form->loadDataFrom(
             [

--- a/tests/GroupDiscountConstraintTest.php
+++ b/tests/GroupDiscountConstraintTest.php
@@ -32,12 +32,12 @@ class GroupDiscountConstraintTest extends SapphireTest
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => 'Special Members Coupon',
-            'Code' => 'GROUPED',
-            'Type' => 'Percent',
-            'Percent' => 0.9,
-            'Active' => 1,
-            'GroupID' => $this->objFromFixture(Group::class, 'resellers')->ID
+                'Title' => 'Special Members Coupon',
+                'Code' => 'GROUPED',
+                'Type' => 'Percent',
+                'Percent' => 0.9,
+                'Active' => 1,
+                'GroupID' => $this->objFromFixture(Group::class, 'resellers')->ID
             ]
         );
         $orderCoupon->write();

--- a/tests/GroupDiscountConstraintTest.php
+++ b/tests/GroupDiscountConstraintTest.php
@@ -16,6 +16,9 @@ class GroupDiscountConstraintTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+    protected Order $othercart;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -24,7 +27,7 @@ class GroupDiscountConstraintTest extends SapphireTest
         $this->othercart = $this->objFromFixture(Order::class, 'othercart');
     }
 
-    public function testMemberGroup()
+    public function testMemberGroup(): void
     {
         $coupon = OrderCoupon::create(
             [
@@ -44,7 +47,9 @@ class GroupDiscountConstraintTest extends SapphireTest
             'CouponCode' => $coupon->Code,
             'Member' => $this->objFromFixture(Member::class, 'bobjones')
         ];
-        $this->assertTrue($coupon->validateOrder($this->othercart, $context),
-            'Valid because member is in resellers group');
+        $this->assertTrue(
+            $coupon->validateOrder($this->othercart, $context),
+            'Valid because member is in resellers group'
+        );
     }
 }

--- a/tests/GroupDiscountConstraintTest.php
+++ b/tests/GroupDiscountConstraintTest.php
@@ -30,7 +30,7 @@ class GroupDiscountConstraintTest extends SapphireTest
 
     public function testMemberGroup(): void
     {
-        $coupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => 'Special Members Coupon',
             'Code' => 'GROUPED',
@@ -40,16 +40,16 @@ class GroupDiscountConstraintTest extends SapphireTest
             'GroupID' => $this->objFromFixture(Group::class, 'resellers')->ID
             ]
         );
-        $coupon->write();
+        $orderCoupon->write();
 
-        $context = ['CouponCode' => $coupon->Code];
-        $this->assertFalse($coupon->validateOrder($this->cart, $context), 'Invalid for memberless order');
+        $context = ['CouponCode' => $orderCoupon->Code];
+        $this->assertFalse($orderCoupon->validateOrder($this->cart, $context), 'Invalid for memberless order');
         $context = [
-            'CouponCode' => $coupon->Code,
+            'CouponCode' => $orderCoupon->Code,
             'Member' => $this->objFromFixture(Member::class, 'bobjones')
         ];
         $this->assertTrue(
-            $coupon->validateOrder($this->othercart, $context),
+            $orderCoupon->validateOrder($this->othercart, $context),
             'Valid because member is in resellers group'
         );
     }

--- a/tests/GroupDiscountConstraintTest.php
+++ b/tests/GroupDiscountConstraintTest.php
@@ -17,9 +17,10 @@ class GroupDiscountConstraintTest extends SapphireTest
     ];
 
     protected Order $cart;
+
     protected Order $othercart;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();

--- a/tests/MembershipDiscountConstraintTest.php
+++ b/tests/MembershipDiscountConstraintTest.php
@@ -9,11 +9,14 @@ use SilverShop\Model\Order;
 use SilverShop\Discounts\Model\OrderDiscount;
 
 
-class MembershipDiscountConstraintTest extends SapphireTest{
+class MembershipDiscountConstraintTest extends SapphireTest
+{
 
     protected static $fixture_file = [
         'shop.yml'
     ];
+
+    protected Order $cart;
 
     public function setUp(): void
     {
@@ -22,7 +25,7 @@ class MembershipDiscountConstraintTest extends SapphireTest{
         $this->cart = $this->objFromFixture(Order::class, 'cart');
     }
 
-    public function testMembership()
+    public function testMembership(): void
     {
         $discount = OrderDiscount::create(
             [

--- a/tests/MembershipDiscountConstraintTest.php
+++ b/tests/MembershipDiscountConstraintTest.php
@@ -28,9 +28,9 @@ class MembershipDiscountConstraintTest extends SapphireTest
     {
         $orderDiscount = OrderDiscount::create(
             [
-            'Title' => 'Membership Coupon',
-            'Type' => 'Amount',
-            'Amount' => 1.33
+                'Title' => 'Membership Coupon',
+                'Type' => 'Amount',
+                'Amount' => 1.33
             ]
         );
         $orderDiscount->write();

--- a/tests/MembershipDiscountConstraintTest.php
+++ b/tests/MembershipDiscountConstraintTest.php
@@ -17,7 +17,7 @@ class MembershipDiscountConstraintTest extends SapphireTest
 
     protected Order $cart;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();

--- a/tests/MembershipDiscountConstraintTest.php
+++ b/tests/MembershipDiscountConstraintTest.php
@@ -8,7 +8,6 @@ use SilverStripe\Security\Member;
 use SilverShop\Model\Order;
 use SilverShop\Discounts\Model\OrderDiscount;
 
-
 class MembershipDiscountConstraintTest extends SapphireTest
 {
 
@@ -45,6 +44,6 @@ class MembershipDiscountConstraintTest extends SapphireTest
         ];
         $this->assertFalse($discount->validateOrder($this->cart, $context), 'Invalid because wrong member present');
         $context = ['Member' => $member];
-        $this->assertTrue($discount->validateOrder($this->cart, $context), 'Valid because correct member present' .$discount->getMessage());
+        $this->assertTrue($discount->validateOrder($this->cart, $context), 'Valid because correct member present' . $discount->getMessage());
     }
 }

--- a/tests/MembershipDiscountConstraintTest.php
+++ b/tests/MembershipDiscountConstraintTest.php
@@ -26,24 +26,24 @@ class MembershipDiscountConstraintTest extends SapphireTest
 
     public function testMembership(): void
     {
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => 'Membership Coupon',
             'Type' => 'Amount',
             'Amount' => 1.33
             ]
         );
-        $discount->write();
+        $orderDiscount->write();
 
         $member = $this->objFromFixture(Member::class, 'joebloggs');
-        $discount->Members()->add($member);
+        $orderDiscount->Members()->add($member);
 
-        $this->assertFalse($discount->validateOrder($this->cart), 'Invalid, because no member');
+        $this->assertFalse($orderDiscount->validateOrder($this->cart), 'Invalid, because no member');
         $context = [
             'Member' => $this->objFromFixture(Member::class, 'bobjones')
         ];
-        $this->assertFalse($discount->validateOrder($this->cart, $context), 'Invalid because wrong member present');
+        $this->assertFalse($orderDiscount->validateOrder($this->cart, $context), 'Invalid because wrong member present');
         $context = ['Member' => $member];
-        $this->assertTrue($discount->validateOrder($this->cart, $context), 'Valid because correct member present' . $discount->getMessage());
+        $this->assertTrue($orderDiscount->validateOrder($this->cart, $context), 'Valid because correct member present' . $orderDiscount->getMessage());
     }
 }

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -34,7 +34,7 @@ class OrderCouponTest extends SapphireTest
         parent::setUp();
         ShopTest::setConfiguration();
 
-        Config::inst()->set(OrderCoupon::class, 'minimum_code_length', null);
+        Config::modify()->set(OrderCoupon::class, 'minimum_code_length', null);
 
         $this->socks = $this->objFromFixture(Product::class, 'socks');
         $this->socks->publishRecursive();
@@ -52,7 +52,7 @@ class OrderCouponTest extends SapphireTest
 
     public function testMinimumLengthCode(): void
     {
-        Config::inst()->set(OrderCoupon::class, 'minimum_code_length', 8);
+        Config::modify()->set(OrderCoupon::class, 'minimum_code_length', 8);
         $coupon = OrderCoupon::create();
         $coupon->Code = '1234567';
         $result = $coupon->validate();
@@ -66,7 +66,7 @@ class OrderCouponTest extends SapphireTest
         $result = $coupon->validate();
         $this->assertNotContains('INVALIDMINLENGTH', $result->getMessages());
 
-        Config::inst()->set(OrderCoupon::class, 'minimum_code_length', null);
+        Config::modify()->set(OrderCoupon::class, 'minimum_code_length', null);
 
         $coupon = OrderCoupon::create(['Code' => '1']);
         $result = $coupon->validate();

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -89,7 +89,7 @@ class OrderCouponTest extends SapphireTest
 
         $context = ['CouponCode' => $orderCoupon->Code];
         $this->assertTrue($orderCoupon->validateOrder($this->cart, $context), (string)$orderCoupon->getMessage());
-        $this->assertEqualsWithDelta(4, (int) (int) $orderCoupon->getDiscountValue(10), PHP_FLOAT_EPSILON);
+        $this->assertEqualsWithDelta(4, (int) $orderCoupon->getDiscountValue(10), PHP_FLOAT_EPSILON);
         $this->assertSame(200, (int) $this->calc($this->unpaid, $orderCoupon), '40% off order');
     }
 
@@ -133,7 +133,7 @@ class OrderCouponTest extends SapphireTest
 
     protected function getCalculator(Order $order, OrderCoupon $orderCoupon): Calculator
     {
-        return new Calculator($order, ['CouponCode' => $orderCoupon->Code]);
+        return Calculator::create($order, ['CouponCode' => $orderCoupon->Code]);
     }
 
     protected function calc(Order $order, OrderCoupon $orderCoupon): int|float

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -46,22 +46,22 @@ class OrderCouponTest extends SapphireTest
     public function testMinimumLengthCode(): void
     {
         Config::inst()->set(OrderCoupon::class, 'minimum_code_length', 8);
-        $coupon = new OrderCoupon();
+        $coupon = OrderCoupon::create();
         $coupon->Code = '1234567';
         $result = $coupon->validate();
-        self::assertContains('INVALIDMINLENGTH', $result->getMessages());
+        $this->assertSame('INVALIDMINLENGTH', key($result->getMessages()));
 
-        $coupon = new OrderCoupon();
+        $coupon = OrderCoupon::create();
         $result = $coupon->validate();
         self::assertNotContains('INVALIDMINLENGTH', $result->getMessages(), 'Leaving the Code field generates a code');
 
-        $coupon = new OrderCoupon(['Code' => '12345678']);
+        $coupon = OrderCoupon::create(['Code' => '12345678']);
         $result = $coupon->validate();
         self::assertNotContains('INVALIDMINLENGTH', $result->getMessages());
 
         Config::inst()->set(OrderCoupon::class, 'minimum_code_length', null);
 
-        $coupon = new OrderCoupon(['Code' => '1']);
+        $coupon = OrderCoupon::create(['Code' => '1']);
         $result = $coupon->validate();
         self::assertNotContains('INVALIDMINLENGTH', $result->getMessages());
     }
@@ -122,13 +122,13 @@ class OrderCouponTest extends SapphireTest
         $this->assertFalse($inactivecoupon->validateOrder($this->cart, $context), 'Coupon is not set to active');
     }
 
-    protected function getCalculator($order, $coupon): Calculator
+    protected function getCalculator(Order $order, OrderCoupon $coupon): Calculator
     {
         return new Calculator($order, ['CouponCode' => $coupon->Code]);
     }
 
-    protected function calc($order, $coupon): int|float
+    protected function calc(Order $order, OrderCoupon $order_coupon): int|float
     {
-        return $this->getCalculator($order, $coupon)->calculate();
+        return $this->getCalculator($order, $order_coupon)->calculate();
     }
 }

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -17,6 +17,13 @@ class OrderCouponTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+    protected Order $unpaid;
+    protected Order $othercart;
+    protected Product $socks;
+    protected Product $tshirt;
+    protected Product $mp3player;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -36,7 +43,7 @@ class OrderCouponTest extends SapphireTest
         $this->othercart = $this->objFromFixture(Order::class, 'othercart');
     }
 
-    public function testMinimumLengthCode()
+    public function testMinimumLengthCode(): void
     {
         Config::inst()->set(OrderCoupon::class, 'minimum_code_length', 8);
         $coupon = new OrderCoupon();
@@ -59,7 +66,7 @@ class OrderCouponTest extends SapphireTest
         self::assertNotContains('INVALIDMINLENGTH', $result->getMessages());
     }
 
-    public function testPercent()
+    public function testPercent(): void
     {
         $coupon = OrderCoupon::create(
             [
@@ -78,7 +85,7 @@ class OrderCouponTest extends SapphireTest
         $this->assertEquals(200, $this->calc($this->unpaid, $coupon), '40% off order');
     }
 
-    public function testAmount()
+    public function testAmount(): void
     {
         $coupon = OrderCoupon::create(
             [
@@ -99,7 +106,7 @@ class OrderCouponTest extends SapphireTest
         //TODO: test amount that is greater than item value
     }
 
-    public function testInactiveCoupon()
+    public function testInactiveCoupon(): void
     {
         $inactivecoupon = OrderCoupon::create(
             [
@@ -115,12 +122,12 @@ class OrderCouponTest extends SapphireTest
         $this->assertFalse($inactivecoupon->validateOrder($this->cart, $context), 'Coupon is not set to active');
     }
 
-    protected function getCalculator($order, $coupon)
+    protected function getCalculator($order, $coupon): Calculator
     {
         return new Calculator($order, ['CouponCode' => $coupon->Code]);
     }
 
-    protected function calc($order, $coupon)
+    protected function calc($order, $coupon): int|float
     {
         return $this->getCalculator($order, $coupon)->calculate();
     }

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -60,57 +60,57 @@ class OrderCouponTest extends SapphireTest
 
         $coupon = OrderCoupon::create();
         $result = $coupon->validate();
-        self::assertNotContains('INVALIDMINLENGTH', $result->getMessages(), 'Leaving the Code field generates a code');
+        $this->assertNotContains('INVALIDMINLENGTH', $result->getMessages(), 'Leaving the Code field generates a code');
 
         $coupon = OrderCoupon::create(['Code' => '12345678']);
         $result = $coupon->validate();
-        self::assertNotContains('INVALIDMINLENGTH', $result->getMessages());
+        $this->assertNotContains('INVALIDMINLENGTH', $result->getMessages());
 
         Config::inst()->set(OrderCoupon::class, 'minimum_code_length', null);
 
         $coupon = OrderCoupon::create(['Code' => '1']);
         $result = $coupon->validate();
-        self::assertNotContains('INVALIDMINLENGTH', $result->getMessages());
+        $this->assertNotContains('INVALIDMINLENGTH', $result->getMessages());
     }
 
     public function testPercent(): void
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => '40% off each item',
-            'Code' => '5B97AA9D75',
-            'Type' => 'Percent',
-            'Percent' => 0.40,
-            'StartDate' => '2000-01-01 12:00:00',
-            'EndDate' => '2200-01-01 12:00:00'
+                'Title' => '40% off each item',
+                'Code' => '5B97AA9D75',
+                'Type' => 'Percent',
+                'Percent' => 0.40,
+                'StartDate' => '2000-01-01 12:00:00',
+                'EndDate' => '2200-01-01 12:00:00'
             ]
         );
         $orderCoupon->write();
 
         $context = ['CouponCode' => $orderCoupon->Code];
         $this->assertTrue($orderCoupon->validateOrder($this->cart, $context), (string)$orderCoupon->getMessage());
-        $this->assertEquals(4, $orderCoupon->getDiscountValue(10), '40% off value');
-        $this->assertEquals(200, $this->calc($this->unpaid, $orderCoupon), '40% off order');
+        $this->assertEqualsWithDelta(4, (int) (int) $orderCoupon->getDiscountValue(10), PHP_FLOAT_EPSILON);
+        $this->assertSame(200, (int) $this->calc($this->unpaid, $orderCoupon), '40% off order');
     }
 
     public function testAmount(): void
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => '$10 off each item',
-            'Code' => 'TENDOLLARSOFF',
-            'Type' => 'Amount',
-            'Amount' => 10,
-            'Active' => 1
+                'Title' => '$10 off each item',
+                'Code' => 'TENDOLLARSOFF',
+                'Type' => 'Amount',
+                'Amount' => 10,
+                'Active' => 1
             ]
         );
         $orderCoupon->write();
 
         $context = ['CouponCode' => $orderCoupon->Code];
         $this->assertTrue($orderCoupon->validateOrder($this->cart, $context), (string)$orderCoupon->getMessage());
-        $this->assertEquals($orderCoupon->getDiscountValue(1000), 10, '$10 off fixed value');
+        $this->assertSame(10, (int) $orderCoupon->getDiscountValue(1000), '$10 off fixed value');
         $this->assertTrue($orderCoupon->validateOrder($this->unpaid, $context), (string)$orderCoupon->getMessage());
-        $this->assertEquals(60, $this->calc($this->unpaid, $orderCoupon), '$10 off each item: $60 total');
+        $this->assertEqualsWithDelta(60, (int) $this->calc($this->unpaid, $orderCoupon), PHP_FLOAT_EPSILON);
         //TODO: test amount that is greater than item value
     }
 
@@ -118,11 +118,11 @@ class OrderCouponTest extends SapphireTest
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => 'Not active',
-            'Code' => 'EE891574D6',
-            'Type' => 'Amount',
-            'Amount' => 10,
-            'Active' => 0
+                'Title' => 'Not active',
+                'Code' => 'EE891574D6',
+                'Type' => 'Amount',
+                'Amount' => 10,
+                'Active' => 0
             ]
         );
         $orderCoupon->write();

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -75,7 +75,7 @@ class OrderCouponTest extends SapphireTest
 
     public function testPercent(): void
     {
-        $coupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => '40% off each item',
             'Code' => '5B97AA9D75',
@@ -85,17 +85,17 @@ class OrderCouponTest extends SapphireTest
             'EndDate' => '2200-01-01 12:00:00'
             ]
         );
-        $coupon->write();
+        $orderCoupon->write();
 
-        $context = ['CouponCode' => $coupon->Code];
-        $this->assertTrue($coupon->validateOrder($this->cart, $context), (string)$coupon->getMessage());
-        $this->assertEquals(4, $coupon->getDiscountValue(10), '40% off value');
-        $this->assertEquals(200, $this->calc($this->unpaid, $coupon), '40% off order');
+        $context = ['CouponCode' => $orderCoupon->Code];
+        $this->assertTrue($orderCoupon->validateOrder($this->cart, $context), (string)$orderCoupon->getMessage());
+        $this->assertEquals(4, $orderCoupon->getDiscountValue(10), '40% off value');
+        $this->assertEquals(200, $this->calc($this->unpaid, $orderCoupon), '40% off order');
     }
 
     public function testAmount(): void
     {
-        $coupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => '$10 off each item',
             'Code' => 'TENDOLLARSOFF',
@@ -104,19 +104,19 @@ class OrderCouponTest extends SapphireTest
             'Active' => 1
             ]
         );
-        $coupon->write();
+        $orderCoupon->write();
 
-        $context = ['CouponCode' => $coupon->Code];
-        $this->assertTrue($coupon->validateOrder($this->cart, $context), (string)$coupon->getMessage());
-        $this->assertEquals($coupon->getDiscountValue(1000), 10, '$10 off fixed value');
-        $this->assertTrue($coupon->validateOrder($this->unpaid, $context), (string)$coupon->getMessage());
-        $this->assertEquals(60, $this->calc($this->unpaid, $coupon), '$10 off each item: $60 total');
+        $context = ['CouponCode' => $orderCoupon->Code];
+        $this->assertTrue($orderCoupon->validateOrder($this->cart, $context), (string)$orderCoupon->getMessage());
+        $this->assertEquals($orderCoupon->getDiscountValue(1000), 10, '$10 off fixed value');
+        $this->assertTrue($orderCoupon->validateOrder($this->unpaid, $context), (string)$orderCoupon->getMessage());
+        $this->assertEquals(60, $this->calc($this->unpaid, $orderCoupon), '$10 off each item: $60 total');
         //TODO: test amount that is greater than item value
     }
 
     public function testInactiveCoupon(): void
     {
-        $inactivecoupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => 'Not active',
             'Code' => 'EE891574D6',
@@ -125,19 +125,19 @@ class OrderCouponTest extends SapphireTest
             'Active' => 0
             ]
         );
-        $inactivecoupon->write();
+        $orderCoupon->write();
 
-        $context = ['CouponCode' => $inactivecoupon->Code];
-        $this->assertFalse($inactivecoupon->validateOrder($this->cart, $context), 'Coupon is not set to active');
+        $context = ['CouponCode' => $orderCoupon->Code];
+        $this->assertFalse($orderCoupon->validateOrder($this->cart, $context), 'Coupon is not set to active');
     }
 
-    protected function getCalculator(Order $order, OrderCoupon $coupon): Calculator
+    protected function getCalculator(Order $order, OrderCoupon $orderCoupon): Calculator
     {
-        return new Calculator($order, ['CouponCode' => $coupon->Code]);
+        return new Calculator($order, ['CouponCode' => $orderCoupon->Code]);
     }
 
-    protected function calc(Order $order, OrderCoupon $order_coupon): int|float
+    protected function calc(Order $order, OrderCoupon $orderCoupon): int|float
     {
-        return $this->getCalculator($order, $order_coupon)->calculate();
+        return $this->getCalculator($order, $orderCoupon)->calculate();
     }
 }

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -18,13 +18,18 @@ class OrderCouponTest extends SapphireTest
     ];
 
     protected Order $cart;
+
     protected Order $unpaid;
+
     protected Order $othercart;
+
     protected Product $socks;
+
     protected Product $tshirt;
+
     protected Product $mp3player;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();
@@ -33,8 +38,10 @@ class OrderCouponTest extends SapphireTest
 
         $this->socks = $this->objFromFixture(Product::class, 'socks');
         $this->socks->publishRecursive();
+
         $this->tshirt = $this->objFromFixture(Product::class, 'tshirt');
         $this->tshirt->publishRecursive();
+
         $this->mp3player = $this->objFromFixture(Product::class, 'mp3player');
         $this->mp3player->publishRecursive();
 
@@ -79,6 +86,7 @@ class OrderCouponTest extends SapphireTest
             ]
         );
         $coupon->write();
+
         $context = ['CouponCode' => $coupon->Code];
         $this->assertTrue($coupon->validateOrder($this->cart, $context), (string)$coupon->getMessage());
         $this->assertEquals(4, $coupon->getDiscountValue(10), '40% off value');
@@ -118,6 +126,7 @@ class OrderCouponTest extends SapphireTest
             ]
         );
         $inactivecoupon->write();
+
         $context = ['CouponCode' => $inactivecoupon->Code];
         $this->assertFalse($inactivecoupon->validateOrder($this->cart, $context), 'Coupon is not set to active');
     }

--- a/tests/OrderDiscountTest.php
+++ b/tests/OrderDiscountTest.php
@@ -18,7 +18,7 @@ class OrderDiscountTest extends SapphireTest
 
     protected Order $cart;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();

--- a/tests/OrderDiscountTest.php
+++ b/tests/OrderDiscountTest.php
@@ -16,6 +16,8 @@ class OrderDiscountTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -26,7 +28,7 @@ class OrderDiscountTest extends SapphireTest
     /**
      * Check that available discounts are matched to the current order.
      */
-    public function testManyMatches()
+    public function testManyMatches(): void
     {
         OrderDiscount::create(
             [
@@ -52,7 +54,7 @@ class OrderDiscountTest extends SapphireTest
         );
     }
 
-    public function testPercent()
+    public function testPercent(): void
     {
         OrderDiscount::create(
             [
@@ -69,7 +71,7 @@ class OrderDiscountTest extends SapphireTest
         );
     }
 
-    public function testAmount()
+    public function testAmount(): void
     {
         OrderDiscount::create(
             [
@@ -86,7 +88,7 @@ class OrderDiscountTest extends SapphireTest
         );
     }
 
-    public function testUseCount()
+    public function testUseCount(): void
     {
         //check that order with payment started counts as a use
         $discount = $this->objFromFixture(OrderDiscount::class, 'paymentused');

--- a/tests/OrderDiscountTest.php
+++ b/tests/OrderDiscountTest.php
@@ -44,13 +44,13 @@ class OrderDiscountTest extends SapphireTest
             'Amount' => 5
             ]
         )->write();
-        $matches = OrderDiscount::get_matching($this->cart);
+        $arrayList = OrderDiscount::get_matching($this->cart);
         $this->assertListEquals(
             [
             ['Title' => '10% off'],
             ['Title' => '$5 off'],
             ],
-            $matches
+            $arrayList
         );
     }
 
@@ -91,7 +91,7 @@ class OrderDiscountTest extends SapphireTest
     public function testUseCount(): void
     {
         //check that order with payment started counts as a use
-        $discount = $this->objFromFixture(OrderDiscount::class, 'paymentused');
+        $orderDiscount = $this->objFromFixture(OrderDiscount::class, 'paymentused');
         $payment = $this->objFromFixture(Payment::class, 'paymentstarted_recent');
 
         // set timeout to 60 minutes
@@ -99,15 +99,15 @@ class OrderDiscountTest extends SapphireTest
         //set payment to be created 20 min ago
         $payment->Created = date('Y-m-d H:i:s', strtotime('-20 minutes'));
         $payment->write();
-        $this->assertEquals(1, $discount->getUseCount());
+        $this->assertEquals(1, $orderDiscount->getUseCount());
         //set payment ot be created 2 days ago
         $payment->Created = date('Y-m-d H:i:s', strtotime('-2 days'));
         $payment->write();
-        $this->assertEquals(0, $discount->getUseCount());
+        $this->assertEquals(0, $orderDiscount->getUseCount());
         //failed payments should be ignored
         $payment->Created = date('Y-m-d H:i:s', strtotime('-20 minutes'));
         $payment->Status = 'Void';
         $payment->write();
-        $this->assertEquals(0, $discount->getUseCount());
+        $this->assertEquals(0, $orderDiscount->getUseCount());
     }
 }

--- a/tests/OrderDiscountTest.php
+++ b/tests/OrderDiscountTest.php
@@ -32,23 +32,23 @@ class OrderDiscountTest extends SapphireTest
     {
         OrderDiscount::create(
             [
-            'Title' => '10% off',
-            'Type' => 'Percent',
-            'Percent' => 0.10
+                'Title' => '10% off',
+                'Type' => 'Percent',
+                'Percent' => 0.10
             ]
         )->write();
         OrderDiscount::create(
             [
-            'Title' => '$5 off',
-            'Type' => 'Amount',
-            'Amount' => 5
+                'Title' => '$5 off',
+                'Type' => 'Amount',
+                'Amount' => 5
             ]
         )->write();
         $arrayList = OrderDiscount::get_matching($this->cart);
         $this->assertListEquals(
             [
-            ['Title' => '10% off'],
-            ['Title' => '$5 off'],
+                ['Title' => '10% off'],
+                ['Title' => '$5 off'],
             ],
             $arrayList
         );
@@ -58,14 +58,14 @@ class OrderDiscountTest extends SapphireTest
     {
         OrderDiscount::create(
             [
-            'Title' => '10% off',
-            'Type' => 'Percent',
-            'Percent' => 0.10
+                'Title' => '10% off',
+                'Type' => 'Percent',
+                'Percent' => 0.10
             ]
         )->write();
         $this->assertListEquals(
             [
-            ['Title' => '10% off']
+                ['Title' => '10% off']
             ],
             OrderDiscount::get_matching($this->cart)
         );
@@ -75,14 +75,14 @@ class OrderDiscountTest extends SapphireTest
     {
         OrderDiscount::create(
             [
-            'Title' => '$5 off',
-            'Type' => 'Amount',
-            'Amount' => 5
+                'Title' => '$5 off',
+                'Type' => 'Amount',
+                'Amount' => 5
             ]
         )->write();
         $this->assertListEquals(
             [
-            ['Title' => '$5 off']
+                ['Title' => '$5 off']
             ],
             OrderDiscount::get_matching($this->cart)
         );
@@ -99,15 +99,15 @@ class OrderDiscountTest extends SapphireTest
         //set payment to be created 20 min ago
         $payment->Created = date('Y-m-d H:i:s', strtotime('-20 minutes'));
         $payment->write();
-        $this->assertEquals(1, $orderDiscount->getUseCount());
+        $this->assertSame(1, $orderDiscount->getUseCount());
         //set payment ot be created 2 days ago
         $payment->Created = date('Y-m-d H:i:s', strtotime('-2 days'));
         $payment->write();
-        $this->assertEquals(0, $orderDiscount->getUseCount());
+        $this->assertSame(0, $orderDiscount->getUseCount());
         //failed payments should be ignored
         $payment->Created = date('Y-m-d H:i:s', strtotime('-20 minutes'));
         $payment->Status = 'Void';
         $payment->write();
-        $this->assertEquals(0, $orderDiscount->getUseCount());
+        $this->assertSame(0, $orderDiscount->getUseCount());
     }
 }

--- a/tests/PartialUseDiscountTest.php
+++ b/tests/PartialUseDiscountTest.php
@@ -13,7 +13,7 @@ class PartialUseDiscountTest extends SapphireTest
         'PartialUseDiscount.yml'
     ];
 
-    public function testCreateRemainder()
+    public function testCreateRemainder(): void
     {
         //basic remainder
         $discount = $this->objFromFixture(PartialUseDiscount::class, 'partial');
@@ -46,7 +46,7 @@ class PartialUseDiscountTest extends SapphireTest
         );
     }
 
-    public function testCheckoutProcessing()
+    public function testCheckoutProcessing(): void
     {
         $this->markTestIncomplete('This should be tested');
     }

--- a/tests/PartialUseDiscountTest.php
+++ b/tests/PartialUseDiscountTest.php
@@ -20,7 +20,7 @@ class PartialUseDiscountTest extends SapphireTest
         $this->assertNull($discount->createRemainder(5000));
         $this->assertNull($discount->createRemainder(90));
         $remainderdiscount = $discount->createRemainder(40);
-        $this->assertEquals(50, $remainderdiscount->Amount, 'Subtract $40 from $90 discount');
+        $this->assertSame(50, $remainderdiscount->Amount, 'Subtract $40 from $90 discount');
 
         $discount->Active = false;
         $discount->write();
@@ -33,19 +33,22 @@ class PartialUseDiscountTest extends SapphireTest
         $remainder = $discount->createRemainder(40);
         $this->assertListEquals(
             [
-            ['FirstName' => 'Joe']
+                ['FirstName' => 'Joe']
             ],
             $remainder->Members()
         );
         $this->assertListEquals(
             [
-            ['Title' => 'ProductA'],
-            ['Title' => 'ProductB']
+                ['Title' => 'ProductA'],
+                ['Title' => 'ProductB']
             ],
             $remainder->Products()
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCheckoutProcessing(): void
     {
         $this->markTestIncomplete('This should be tested');

--- a/tests/PartialUseDiscountTest.php
+++ b/tests/PartialUseDiscountTest.php
@@ -20,7 +20,7 @@ class PartialUseDiscountTest extends SapphireTest
         $this->assertNull($discount->createRemainder(5000));
         $this->assertNull($discount->createRemainder(90));
         $remainderdiscount = $discount->createRemainder(40);
-        $this->assertSame(50, $remainderdiscount->Amount, 'Subtract $40 from $90 discount');
+        $this->assertSame(50.0, $remainderdiscount->Amount, 'Subtract $40 from $90 discount');
 
         $discount->Active = false;
         $discount->write();

--- a/tests/ProductTypeDiscountConstraintTest.php
+++ b/tests/ProductTypeDiscountConstraintTest.php
@@ -31,7 +31,8 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
         parent::setUp();
         ShopTest::setConfiguration();
         Config::inst()->merge(
-            Discount::class, 'constraints',
+            Discount::class,
+            'constraints',
             [
             'ProductTypeDiscountConstraint'
             ]

--- a/tests/ProductTypeDiscountConstraintTest.php
+++ b/tests/ProductTypeDiscountConstraintTest.php
@@ -38,9 +38,7 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
         Config::inst()->merge(
             Discount::class,
             'constraints',
-            [
-            'ProductTypeDiscountConstraint'
-            ]
+            ['ProductTypeDiscountConstraint']
         );
 
         $this->cart = $this->objFromFixture(Order::class, 'cart');
@@ -63,9 +61,9 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
     {
         $orderDiscount = OrderDiscount::create(
             [
-            'Title' => '20% off each products',
-            'Percent' => 0.2,
-            'ProductTypes' => Product::class
+                'Title' => '20% off each products',
+                'Percent' => 0.2,
+                'ProductTypes' => Product::class
             ]
         );
         $orderDiscount->write();

--- a/tests/ProductTypeDiscountConstraintTest.php
+++ b/tests/ProductTypeDiscountConstraintTest.php
@@ -61,16 +61,16 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
 
     public function testProducts(): void
     {
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => '20% off each products',
             'Percent' => 0.2,
             'ProductTypes' => Product::class
             ]
         );
-        $discount->write();
+        $orderDiscount->write();
 
-        $this->assertTrue($discount->validateOrder($this->cart));
-        $this->assertFalse($discount->validateOrder($this->giftcart));
+        $this->assertTrue($orderDiscount->validateOrder($this->cart));
+        $this->assertFalse($orderDiscount->validateOrder($this->giftcart));
     }
 }

--- a/tests/ProductTypeDiscountConstraintTest.php
+++ b/tests/ProductTypeDiscountConstraintTest.php
@@ -20,13 +20,18 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
     ];
 
     protected GiftVoucherProduct $voucher;
+
     protected Order $cart;
+
     protected Order $giftcart;
+
     protected Product $mp3player;
+
     protected Product $socks;
+
     protected Product $tshirt;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();
@@ -43,8 +48,10 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
 
         $this->socks = $this->objFromFixture(Product::class, 'socks');
         $this->socks->publishRecursive();
+
         $this->tshirt = $this->objFromFixture(Product::class, 'tshirt');
         $this->tshirt->publishRecursive();
+
         $this->mp3player = $this->objFromFixture(Product::class, 'mp3player');
         $this->mp3player->publishRecursive();
 

--- a/tests/ProductTypeDiscountConstraintTest.php
+++ b/tests/ProductTypeDiscountConstraintTest.php
@@ -35,7 +35,7 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
     {
         parent::setUp();
         ShopTest::setConfiguration();
-        Config::inst()->merge(
+        Config::modify()->merge(
             Discount::class,
             'constraints',
             ['ProductTypeDiscountConstraint']

--- a/tests/ProductTypeDiscountConstraintTest.php
+++ b/tests/ProductTypeDiscountConstraintTest.php
@@ -19,11 +19,19 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
         'GiftVouchers.yml'
     ];
 
+    protected GiftVoucherProduct $voucher;
+    protected Order $cart;
+    protected Order $giftcart;
+    protected Product $mp3player;
+    protected Product $socks;
+    protected Product $tshirt;
+
     public function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();
-        Config::inst()->merge(Discount::class, 'constraints',
+        Config::inst()->merge(
+            Discount::class, 'constraints',
             [
             'ProductTypeDiscountConstraint'
             ]
@@ -43,7 +51,7 @@ class ProductTypeDiscountConstraintTest extends SapphireTest
         $this->voucher->copyVersionToStage('Stage', 'Live');
     }
 
-    public function testProducts()
+    public function testProducts(): void
     {
         $discount = OrderDiscount::create(
             [

--- a/tests/ProductsDiscountConstraintTest.php
+++ b/tests/ProductsDiscountConstraintTest.php
@@ -18,15 +18,22 @@ class ProductsDiscountConstraintTest extends SapphireTest
     ];
 
     protected Order $cart;
+
     protected Order $megacart;
+
     protected Order $modifiedcart;
+
     protected Order $othercart;
+
     protected Order $placedorder;
+
     protected Product $mp3player;
+
     protected Product $socks;
+
     protected Product $tshirt;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -39,8 +46,10 @@ class ProductsDiscountConstraintTest extends SapphireTest
 
         $this->socks = $this->objFromFixture(Product::class, 'socks');
         $this->socks->publishRecursive();
+
         $this->tshirt = $this->objFromFixture(Product::class, 'tshirt');
         $this->tshirt->publishRecursive();
+
         $this->mp3player = $this->objFromFixture(Product::class, 'mp3player');
         $this->mp3player->publishRecursive();
     }

--- a/tests/ProductsDiscountConstraintTest.php
+++ b/tests/ProductsDiscountConstraintTest.php
@@ -56,46 +56,46 @@ class ProductsDiscountConstraintTest extends SapphireTest
 
     public function testProducts(): void
     {
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => '20% off each selected products',
             'Percent' => 0.2
             ]
         );
-        $discount->write();
-        $discount->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
-        $this->assertFalse($discount->validateOrder($this->cart));
+        $orderDiscount->write();
+        $orderDiscount->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
+        $this->assertFalse($orderDiscount->validateOrder($this->cart));
         //no products match
         $this->assertListEquals([], OrderDiscount::get_matching($this->cart));
         //add product discount list
-        $discount->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
-        $this->assertFalse($discount->validateOrder($this->cart));
+        $orderDiscount->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
+        $this->assertFalse($orderDiscount->validateOrder($this->cart));
         //no products match
         $this->assertListEquals([], OrderDiscount::get_matching($this->cart));
     }
 
     public function testProductsCoupon(): void
     {
-        $coupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => 'Selected products',
             'Code' => 'PRODUCTS',
             'Percent' => 0.2
             ]
         );
-        $coupon->write();
-        $coupon->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
+        $orderCoupon->write();
+        $orderCoupon->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
 
         $calculator = new Calculator(
             $this->placedorder,
             [
-            'CouponCode' => $coupon->Code
+            'CouponCode' => $orderCoupon->Code
             ]
         );
 
         $this->assertEquals($calculator->calculate(), 20);
         //add another product to coupon product list
-        $coupon->Products()->add($this->objFromFixture(Product::class, 'mp3player'));
+        $orderCoupon->Products()->add($this->objFromFixture(Product::class, 'mp3player'));
         $this->assertEquals($calculator->calculate(), 100);
     }
 
@@ -149,11 +149,11 @@ class ProductsDiscountConstraintTest extends SapphireTest
 
     public function testProductDiscountWithUnpublishedProduct(): void
     {
-        $unpublishedSocks = $this->socks->duplicate();
-        $unpublishedSocks->writeToStage('Stage');
-        $unpublishedSocks->doUnpublish();
+        $product = $this->socks->duplicate();
+        $product->writeToStage('Stage');
+        $product->doUnpublish();
 
-        $discount = OrderDiscount::create(
+        $orderDiscount = OrderDiscount::create(
             [
             'Title' => '20% off each selected products',
             'Percent' => 0.2,
@@ -162,8 +162,8 @@ class ProductsDiscountConstraintTest extends SapphireTest
             ]
         );
 
-        $discount->write();
-        $discount->Products()->add($unpublishedSocks);
+        $orderDiscount->write();
+        $orderDiscount->Products()->add($product);
 
         $order = $this->objFromFixture(Order::class, 'othercart');
         $calculator = new Calculator($order);

--- a/tests/ProductsDiscountConstraintTest.php
+++ b/tests/ProductsDiscountConstraintTest.php
@@ -86,7 +86,7 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $orderCoupon->write();
         $orderCoupon->Products()->add($this->objFromFixture(Product::class, 'tshirt'));
 
-        $calculator = new Calculator(
+        $calculator = Calculator::create(
             $this->placedorder,
             [
                 'CouponCode' => $orderCoupon->Code
@@ -118,26 +118,26 @@ class ProductsDiscountConstraintTest extends SapphireTest
         //10 * tshirt($25) = 250 ..20% off each  = 50
         //2 * mp3player($200) = 400 ..nothing off = 0
         //total discount: 82
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(82, (int) $calculator->calculate(), '20% off selected products');
         //no discount for cart
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertSame(0, (int) $calculator->calculate(), '20% off selected products');
         //no discount for modifiedcart
-        $calculator = new Calculator($this->modifiedcart);
+        $calculator = Calculator::create($this->modifiedcart);
         $this->assertSame(0, (int) $calculator->calculate(), '20% off selected products');
 
         //partial match
-        $discount->ExactProducts = 0;
+        $discount->ExactProducts = false;
         $discount->write();
         //total discount: 82
-        $calculator = new Calculator($this->megacart);
+        $calculator = Calculator::create($this->megacart);
         $this->assertSame(82, (int) $calculator->calculate(), '20% off selected products');
         //discount for cart: 32 (just socks)
-        $calculator = new Calculator($this->cart);
+        $calculator = Calculator::create($this->cart);
         $this->assertEqualsWithDelta(1.6, $calculator->calculate(), PHP_FLOAT_EPSILON);
         //no discount for modified cart
-        $calculator = new Calculator($this->modifiedcart);
+        $calculator = Calculator::create($this->modifiedcart);
         $this->assertSame(0, (int) $calculator->calculate(), '20% off selected products');
 
         //get individual item discounts
@@ -166,7 +166,7 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $orderDiscount->Products()->add($product);
 
         $order = $this->objFromFixture(Order::class, 'othercart');
-        $calculator = new Calculator($order);
+        $calculator = Calculator::create($order);
 
         $this->assertSame(0, (int) $calculator->calculate(), "Product coupon does not apply as draft products don't exist");
     }

--- a/tests/ProductsDiscountConstraintTest.php
+++ b/tests/ProductsDiscountConstraintTest.php
@@ -17,6 +17,15 @@ class ProductsDiscountConstraintTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+    protected Order $megacart;
+    protected Order $modifiedcart;
+    protected Order $othercart;
+    protected Order $placedorder;
+    protected Product $mp3player;
+    protected Product $socks;
+    protected Product $tshirt;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -36,7 +45,7 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $this->mp3player->publishRecursive();
     }
 
-    public function testProducts()
+    public function testProducts(): void
     {
         $discount = OrderDiscount::create(
             [
@@ -56,7 +65,7 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $this->assertListEquals([], OrderDiscount::get_matching($this->cart));
     }
 
-    public function testProductsCoupon()
+    public function testProductsCoupon(): void
     {
         $coupon = OrderCoupon::create(
             [
@@ -81,7 +90,7 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $this->assertEquals($calculator->calculate(), 100);
     }
 
-    public function testProductDiscount()
+    public function testProductDiscount(): void
     {
         $discount = OrderDiscount::create(
             [
@@ -129,7 +138,7 @@ class ProductsDiscountConstraintTest extends SapphireTest
     }
 
 
-    public function testProductDiscountWithUnpublishedProduct()
+    public function testProductDiscountWithUnpublishedProduct(): void
     {
         $unpublishedSocks = $this->socks->duplicate();
         $unpublishedSocks->writeToStage('Stage');

--- a/tests/ProductsDiscountConstraintTest.php
+++ b/tests/ProductsDiscountConstraintTest.php
@@ -58,8 +58,8 @@ class ProductsDiscountConstraintTest extends SapphireTest
     {
         $orderDiscount = OrderDiscount::create(
             [
-            'Title' => '20% off each selected products',
-            'Percent' => 0.2
+                'Title' => '20% off each selected products',
+                'Percent' => 0.2
             ]
         );
         $orderDiscount->write();
@@ -78,9 +78,9 @@ class ProductsDiscountConstraintTest extends SapphireTest
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => 'Selected products',
-            'Code' => 'PRODUCTS',
-            'Percent' => 0.2
+                'Title' => 'Selected products',
+                'Code' => 'PRODUCTS',
+                'Percent' => 0.2
             ]
         );
         $orderCoupon->write();
@@ -89,24 +89,24 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $calculator = new Calculator(
             $this->placedorder,
             [
-            'CouponCode' => $orderCoupon->Code
+                'CouponCode' => $orderCoupon->Code
             ]
         );
 
-        $this->assertEquals($calculator->calculate(), 20);
+        $this->assertSame(20, (int) $calculator->calculate());
         //add another product to coupon product list
         $orderCoupon->Products()->add($this->objFromFixture(Product::class, 'mp3player'));
-        $this->assertEquals($calculator->calculate(), 100);
+        $this->assertSame(100, (int) $calculator->calculate());
     }
 
     public function testProductDiscount(): void
     {
         $discount = OrderDiscount::create(
             [
-            'Title' => '20% off each selected products',
-            'Percent' => 0.2,
-            'Active' => 1,
-            'ExactProducts' => 1
+                'Title' => '20% off each selected products',
+                'Percent' => 0.2,
+                'Active' => 1,
+                'ExactProducts' => 1
             ]
         );
         $discount->write();
@@ -119,31 +119,31 @@ class ProductsDiscountConstraintTest extends SapphireTest
         //2 * mp3player($200) = 400 ..nothing off = 0
         //total discount: 82
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(82, $calculator->calculate(), '20% off selected products');
+        $this->assertSame(82, (int) $calculator->calculate(), '20% off selected products');
         //no discount for cart
         $calculator = new Calculator($this->cart);
-        $this->assertEquals(0, $calculator->calculate(), '20% off selected products');
+        $this->assertSame(0, (int) $calculator->calculate(), '20% off selected products');
         //no discount for modifiedcart
         $calculator = new Calculator($this->modifiedcart);
-        $this->assertEquals(0, $calculator->calculate(), '20% off selected products');
+        $this->assertSame(0, (int) $calculator->calculate(), '20% off selected products');
 
         //partial match
         $discount->ExactProducts = 0;
         $discount->write();
         //total discount: 82
         $calculator = new Calculator($this->megacart);
-        $this->assertEquals(82, $calculator->calculate(), '20% off selected products');
+        $this->assertSame(82, (int) $calculator->calculate(), '20% off selected products');
         //discount for cart: 32 (just socks)
         $calculator = new Calculator($this->cart);
-        $this->assertEquals(1.6, $calculator->calculate(), '20% off selected products');
+        $this->assertEqualsWithDelta(1.6, $calculator->calculate(), PHP_FLOAT_EPSILON);
         //no discount for modified cart
         $calculator = new Calculator($this->modifiedcart);
-        $this->assertEquals(0, $calculator->calculate(), '20% off selected products');
+        $this->assertSame(0, (int) $calculator->calculate(), '20% off selected products');
 
         //get individual item discounts
         $discount = $this->objFromFixture(OrderItem::class, 'megacart_socks')
             ->Discounts()->first();
-        $this->assertEquals(32, $discount->DiscountAmount);
+        $this->assertSame(32, (int) $discount->DiscountAmount);
     }
 
 
@@ -155,10 +155,10 @@ class ProductsDiscountConstraintTest extends SapphireTest
 
         $orderDiscount = OrderDiscount::create(
             [
-            'Title' => '20% off each selected products',
-            'Percent' => 0.2,
-            'Active' => 1,
-            'ExactProducts' => 1
+                'Title' => '20% off each selected products',
+                'Percent' => 0.2,
+                'Active' => 1,
+                'ExactProducts' => 1
             ]
         );
 
@@ -168,6 +168,6 @@ class ProductsDiscountConstraintTest extends SapphireTest
         $order = $this->objFromFixture(Order::class, 'othercart');
         $calculator = new Calculator($order);
 
-        $this->assertEquals(0, $calculator->calculate(), "Product coupon does not apply as draft products don't exist");
+        $this->assertSame(0, (int) $calculator->calculate(), "Product coupon does not apply as draft products don't exist");
     }
 }

--- a/tests/SpecificPriceTest.php
+++ b/tests/SpecificPriceTest.php
@@ -40,10 +40,10 @@ class SpecificPriceTest extends SapphireTest
 
     public function testProductPricePercentage(): void
     {
-        $discount = $this->objFromFixture(SpecificPrice::class, 'raspberrypi_dateconstrained');
-        $discount->DiscountPercent = 0.5;
-        $discount->Price = 0;
-        $discount->write();
+        $specificPrice = $this->objFromFixture(SpecificPrice::class, 'raspberrypi_dateconstrained');
+        $specificPrice->DiscountPercent = 0.5;
+        $specificPrice->Price = 0;
+        $specificPrice->write();
         $product = $this->objFromFixture(Product::class, 'raspberrypi');
         $this->assertEquals(25, $product->sellingPrice());
         $this->assertTrue($product->IsReduced());
@@ -52,10 +52,10 @@ class SpecificPriceTest extends SapphireTest
 
     public function testProductVariationPricePercentage(): void
     {
-        $discount = $this->objFromFixture(SpecificPrice::class, 'robot_30gb_specific');
-        $discount->DiscountPercent = 0.5;
-        $discount->Price = 0;
-        $discount->write();
+        $specificPrice = $this->objFromFixture(SpecificPrice::class, 'robot_30gb_specific');
+        $specificPrice->DiscountPercent = 0.5;
+        $specificPrice->Price = 0;
+        $specificPrice->write();
         $variation = $this->objFromFixture(Variation::class, 'robot_30gb');
         $this->assertEquals(50, $variation->sellingPrice());
         $this->assertTrue($variation->IsReduced());

--- a/tests/SpecificPriceTest.php
+++ b/tests/SpecificPriceTest.php
@@ -25,17 +25,17 @@ class SpecificPriceTest extends SapphireTest
     public function testProductPrice(): void
     {
         $product = $this->objFromFixture(Product::class, 'raspberrypi');
-        $this->assertEquals(45, $product->sellingPrice());
+        $this->assertSame(45, (int) $product->sellingPrice());
         $this->assertTrue($product->IsReduced());
-        $this->assertEquals(5, $product->getTotalReduction());
+        $this->assertSame(5, (int) $product->getTotalReduction());
     }
 
     public function testProductVariationPrice(): void
     {
         $variation = $this->objFromFixture(Variation::class, 'robot_30gb');
-        $this->assertEquals(90, $variation->sellingPrice());
+        $this->assertSame(90, (int) $variation->sellingPrice());
         $this->assertTrue($variation->IsReduced());
-        $this->assertEquals(10, $variation->getTotalReduction());
+        $this->assertSame(10, (int) $variation->getTotalReduction());
     }
 
     public function testProductPricePercentage(): void
@@ -45,9 +45,9 @@ class SpecificPriceTest extends SapphireTest
         $specificPrice->Price = 0;
         $specificPrice->write();
         $product = $this->objFromFixture(Product::class, 'raspberrypi');
-        $this->assertEquals(25, $product->sellingPrice());
+        $this->assertSame(25, (int) $product->sellingPrice());
         $this->assertTrue($product->IsReduced());
-        $this->assertEquals(25, $product->getTotalReduction());
+        $this->assertSame(25, (int) $product->getTotalReduction());
     }
 
     public function testProductVariationPricePercentage(): void
@@ -57,8 +57,8 @@ class SpecificPriceTest extends SapphireTest
         $specificPrice->Price = 0;
         $specificPrice->write();
         $variation = $this->objFromFixture(Variation::class, 'robot_30gb');
-        $this->assertEquals(50, $variation->sellingPrice());
+        $this->assertSame(50, (int) $variation->sellingPrice());
         $this->assertTrue($variation->IsReduced());
-        $this->assertEquals(50, $variation->getTotalReduction());
+        $this->assertSame(50, (int) $variation->getTotalReduction());
     }
 }

--- a/tests/SpecificPriceTest.php
+++ b/tests/SpecificPriceTest.php
@@ -22,7 +22,7 @@ class SpecificPriceTest extends SapphireTest
         Variation::add_extension(SpecificPricingExtension::class);
     }
 
-    public function testProductPrice()
+    public function testProductPrice(): void
     {
         $product = $this->objFromFixture(Product::class, 'raspberrypi');
         $this->assertEquals(45, $product->sellingPrice());
@@ -30,7 +30,7 @@ class SpecificPriceTest extends SapphireTest
         $this->assertEquals(5, $product->getTotalReduction());
     }
 
-    public function testProductVariationPrice()
+    public function testProductVariationPrice(): void
     {
         $variation = $this->objFromFixture(Variation::class, 'robot_30gb');
         $this->assertEquals(90, $variation->sellingPrice());
@@ -38,7 +38,7 @@ class SpecificPriceTest extends SapphireTest
         $this->assertEquals(10, $variation->getTotalReduction());
     }
 
-    public function testProductPricePercentage()
+    public function testProductPricePercentage(): void
     {
         $discount = $this->objFromFixture(SpecificPrice::class, 'raspberrypi_dateconstrained');
         $discount->DiscountPercent = 0.5;
@@ -50,7 +50,7 @@ class SpecificPriceTest extends SapphireTest
         $this->assertEquals(25, $product->getTotalReduction());
     }
 
-    public function testProductVariationPricePercentage()
+    public function testProductVariationPricePercentage(): void
     {
         $discount = $this->objFromFixture(SpecificPrice::class, 'robot_30gb_specific');
         $discount->DiscountPercent = 0.5;

--- a/tests/UseLimitDiscountConstraintTest.php
+++ b/tests/UseLimitDiscountConstraintTest.php
@@ -17,7 +17,7 @@ class UseLimitDiscountConstraintTest extends SapphireTest
 
     protected Order $cart;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();

--- a/tests/UseLimitDiscountConstraintTest.php
+++ b/tests/UseLimitDiscountConstraintTest.php
@@ -15,6 +15,8 @@ class UseLimitDiscountConstraintTest extends SapphireTest
         'Discounts.yml'
     ];
 
+    protected Order $cart;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -22,14 +24,16 @@ class UseLimitDiscountConstraintTest extends SapphireTest
         $this->cart = $this->objFromFixture(Order::class, 'cart');
     }
 
-    public function testUseLimit()
+    public function testUseLimit(): void
     {
         $coupon = $this->objFromFixture(OrderCoupon::class, 'used');
         $context = ['CouponCode' => $coupon->Code];
         $this->assertFalse($coupon->validateOrder($this->cart, $context), 'Coupon is already used');
         $coupon = $this->objFromFixture(OrderCoupon::class, 'limited');
         $context = ['CouponCode' => $coupon->Code];
-        $this->assertTrue($coupon->validateOrder($this->cart, $context),
-            'Coupon has been used, but can continue to be used');
+        $this->assertTrue(
+            $coupon->validateOrder($this->cart, $context),
+            'Coupon has been used, but can continue to be used'
+        );
     }
 }

--- a/tests/ValueDiscountConstraintTest.php
+++ b/tests/ValueDiscountConstraintTest.php
@@ -37,13 +37,13 @@ class ValueDiscountConstraintTest extends SapphireTest
     {
         $orderCoupon = OrderCoupon::create(
             [
-            'Title' => 'Orders 200 and more',
-            'Code' => '200PLUS',
-            'Type' => 'Amount',
-            'Amount' => 35,
-            'ForItems' => 0,
-            'ForCart' => 1,
-            'MinOrderValue' => 200
+                'Title' => 'Orders 200 and more',
+                'Code' => '200PLUS',
+                'Type' => 'Amount',
+                'Amount' => 35,
+                'ForItems' => 0,
+                'ForCart' => 1,
+                'MinOrderValue' => 200
             ]
         );
         $orderCoupon->write();
@@ -54,10 +54,10 @@ class ValueDiscountConstraintTest extends SapphireTest
         $this->assertTrue($orderCoupon->validateOrder($this->placedorder, $context), '$500 order is enough');
 
         $calculator = new Calculator($this->cart, $context);
-        $this->assertEquals(0, $calculator->calculate());
+        $this->assertSame(0, (int) $calculator->calculate());
         $calculator = new Calculator($this->othercart, $context);
-        $this->assertEquals(35, $calculator->calculate());
+        $this->assertSame(35, (int) $calculator->calculate());
         $calculator = new Calculator($this->placedorder, $context);
-        $this->assertEquals(35, $calculator->calculate());
+        $this->assertSame(35, (int) $calculator->calculate());
     }
 }

--- a/tests/ValueDiscountConstraintTest.php
+++ b/tests/ValueDiscountConstraintTest.php
@@ -35,7 +35,7 @@ class ValueDiscountConstraintTest extends SapphireTest
 
     public function testMinOrderValue(): void
     {
-        $coupon = OrderCoupon::create(
+        $orderCoupon = OrderCoupon::create(
             [
             'Title' => 'Orders 200 and more',
             'Code' => '200PLUS',
@@ -46,12 +46,12 @@ class ValueDiscountConstraintTest extends SapphireTest
             'MinOrderValue' => 200
             ]
         );
-        $coupon->write();
+        $orderCoupon->write();
 
-        $context = ['CouponCode' => $coupon->Code];
-        $this->assertFalse($coupon->validateOrder($this->cart, $context), "$8 order isn't enough");
-        $this->assertTrue($coupon->validateOrder($this->othercart, $context), '$200 is enough');
-        $this->assertTrue($coupon->validateOrder($this->placedorder, $context), '$500 order is enough');
+        $context = ['CouponCode' => $orderCoupon->Code];
+        $this->assertFalse($orderCoupon->validateOrder($this->cart, $context), "$8 order isn't enough");
+        $this->assertTrue($orderCoupon->validateOrder($this->othercart, $context), '$200 is enough');
+        $this->assertTrue($orderCoupon->validateOrder($this->placedorder, $context), '$500 order is enough');
 
         $calculator = new Calculator($this->cart, $context);
         $this->assertEquals(0, $calculator->calculate());

--- a/tests/ValueDiscountConstraintTest.php
+++ b/tests/ValueDiscountConstraintTest.php
@@ -11,15 +11,19 @@ use SilverShop\Model\Order;
 class ValueDiscountConstraintTest extends SapphireTest
 {
 
+    public $placedorder;
+
     protected static $fixture_file = [
         'shop.yml'
     ];
 
     protected Order $cart;
+
     protected Order $othercart;
+
     protected Order $placeorder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ShopTest::setConfiguration();
@@ -43,6 +47,7 @@ class ValueDiscountConstraintTest extends SapphireTest
             ]
         );
         $coupon->write();
+
         $context = ['CouponCode' => $coupon->Code];
         $this->assertFalse($coupon->validateOrder($this->cart, $context), "$8 order isn't enough");
         $this->assertTrue($coupon->validateOrder($this->othercart, $context), '$200 is enough');

--- a/tests/ValueDiscountConstraintTest.php
+++ b/tests/ValueDiscountConstraintTest.php
@@ -15,6 +15,10 @@ class ValueDiscountConstraintTest extends SapphireTest
         'shop.yml'
     ];
 
+    protected Order $cart;
+    protected Order $othercart;
+    protected Order $placeorder;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -25,7 +29,7 @@ class ValueDiscountConstraintTest extends SapphireTest
         $this->placedorder = $this->objFromFixture(Order::class, 'unpaid');
     }
 
-    public function testMinOrderValue()
+    public function testMinOrderValue(): void
     {
         $coupon = OrderCoupon::create(
             [

--- a/tests/ValueDiscountConstraintTest.php
+++ b/tests/ValueDiscountConstraintTest.php
@@ -53,11 +53,11 @@ class ValueDiscountConstraintTest extends SapphireTest
         $this->assertTrue($orderCoupon->validateOrder($this->othercart, $context), '$200 is enough');
         $this->assertTrue($orderCoupon->validateOrder($this->placedorder, $context), '$500 order is enough');
 
-        $calculator = new Calculator($this->cart, $context);
+        $calculator = Calculator::create($this->cart, $context);
         $this->assertSame(0, (int) $calculator->calculate());
-        $calculator = new Calculator($this->othercart, $context);
+        $calculator = Calculator::create($this->othercart, $context);
         $this->assertSame(35, (int) $calculator->calculate());
-        $calculator = new Calculator($this->placedorder, $context);
+        $calculator = Calculator::create($this->placedorder, $context);
         $this->assertSame(35, (int) $calculator->calculate());
     }
 }


### PR DESCRIPTION
Utilising [Rector](https://github.com/Cambis/silverstripe-rector) & [PHPStan](https://github.com/Cambis/silverstan), upgrade silvershop-discounts for the latest features of PHP (up to 8.1). Add property & return types, run PHP Code Sniffer, replace new with ::create for SilverStripe code quality, replace DataExtension with Extension in preparation for SS6, remove dead code, and add exists() checks for code safety. PHPStan passes to level 5. Add Github Action for tests.  Update .editorconfig.  